### PR TITLE
Ins 193: SRA titles now appear in Datasets tab on Explore page

### DIFF
--- a/dataloader/config/es_indices_bento.yml
+++ b/dataloader/config/es_indices_bento.yml
@@ -794,7 +794,7 @@ Indices:
           COLLECT(DISTINCT pr.award_amount_category) AS award_amounts,
           COLLECT(DISTINCT pr.queried_project_id) AS queried_project_ids,
           dt.accession AS accession,
-          dt.title AS title,
+          COALESCE(dt.title, dt.study_title) AS title,
           dt.release_date AS release_date,
           dt.registration_date AS registration_date,
           dt.bioproject_accession AS bioproject_accession,
@@ -948,6 +948,9 @@ Indices:
         fields:
           search:
             type: search_as_you_type
+          sort:
+            type: keyword
+            normalizer: lowercase
       project_type:
         type: keyword
       abstract_text:

--- a/dataloader/config/es_loader.yml
+++ b/dataloader/config/es_loader.yml
@@ -1,17 +1,17 @@
 Config:
   # Neo4j URL with port number
-  neo4j_uri: "bolt://localhost:7687"
+  neo4j_uri: "bolt://10.0.0.13:7687"
   # Neo4j user name, default is neo4j
   neo4j_user: neo4j
   # Password for Neo4j user
-  neo4j_password: "123456"
+  neo4j_password: "neo4j_password"
   # Elastic search host name or IP, without trailing slash
-  es_host: localhost:9200
+  es_host: 10.0.0.13:9200
   # Path to about file
   about_file: model-desc/aboutPagesContent.yaml
 
   model_files:
-    - model-desc/bento_model_file.yaml
-    - model-desc/bento_model_properties.yaml
+    - model-desc/ins_model_file.yaml
+    - model-desc/ins_model_properties.yaml
 
-  prop_file: model-desc/props-bento.yml
+  prop_file: model-desc/props-ins.yml


### PR DESCRIPTION
For datasets, GEOs and dbGaPs have 'title' attributes while SRAs have a 'study_title' attribute. Data was not loaded properly into Elasticsearch/OpenSearch due to this oversight. The 'title' property in the 'datasets' index now properly loads either 'title' or 'study_title', whichever applies.