### PR TITLE
INS-235 add sort field to program_officers.

### DIFF
--- a/dataloader/config/es_indices_bento.yml
+++ b/dataloader/config/es_indices_bento.yml
@@ -1015,6 +1015,9 @@ Indices:
         fields:
           search:
             type: search_as_you_type
+          sort:
+            type: keyword
+            normalizer: lowercase
       nci_funded_amount:
         type: integer
       award_notice_date:


### PR DESCRIPTION
Added sub-field to program_officers property in 'projects' index. This is for the downstream column in the Project tab on the Explore page -- it needs to be sortable.