### PR TITLE
INS-379: Fixed Dataset links

### DIFF
--- a/dataloader/config/es_indices_bento.yml
+++ b/dataloader/config/es_indices_bento.yml
@@ -807,8 +807,8 @@ Indices:
             WHEN 'dbgap' THEN 'dbGaP' END AS transformed_type,
           CASE LABELS(dt)[0]
             WHEN 'geo' THEN 'https://www.ncbi.nlm.nih.gov/gds/?term=' + dt.accession
-            WHEN 'sra' THEN 'https://www.ncbi.nlm.nih.gov/gds/?term=' + dt.accession
-            WHEN 'dbgap' THEN 'https://www.ncbi.nlm.nih.gov/gds/?term=' + dt.accession END AS link
+            WHEN 'sra' THEN 'https://trace.ncbi.nlm.nih.gov/Traces/sra/?study=' + dt.accession
+            WHEN 'dbgap' THEN 'https://www.ncbi.nlm.nih.gov/gap/?term=' + dt.accession END AS link
       "
 
   - index_name: publications


### PR DESCRIPTION
All of the Dataset accession links pointed to the GEO website. Now the SRA accessions point to the SRA website and the dbGaP accessions point to the dbGaP website.