### PR TITLE
Ins 403: Sorting with null values on Publications tab

### DIFF
--- a/dataloader/config/es_indices_bento.yml
+++ b/dataloader/config/es_indices_bento.yml
@@ -872,10 +872,12 @@ Indices:
         type: keyword
       relative_citation_ratio:
         type: float
+        null_value: -1
       rcr_range:
         type: keyword
       nih_percentile:
         type: float
+        null_value: -1
       doi:
         type: keyword
     # Cypher query will be used to retrieve data from Neo4j, and index into Elasticsearch


### PR DESCRIPTION
On the Explore page's table's publication's tab, null values in the RCR and NIH Percentile columns did not sort null values properly upon sorting ascending and descending on those columns.