### PR TITLE
INS-480: Format digest files for certain outputs

### DIFF
--- a/digest_data/digest_clinical_trial.tsv
+++ b/digest_data/digest_clinical_trial.tsv
@@ -1,0 +1,179 @@
+type	clinical_trial_id	title	last_update_posted	recruitment_status	publication_id	queried_project_id
+clinical_trial	NCT04514341	Implementing a Multilevel Intervention to Accelerate Colorectal Cancer Screening and Follow-up	14-Aug-2020	Not yet recruiting	33121536	UG3CA233229
+clinical_trial	NCT04514341	Implementing a Multilevel Intervention to Accelerate Colorectal Cancer Screening and Follow-up	14-Aug-2020	Not yet recruiting	33121536	UH3CA233229
+clinical_trial	NCT04763915	Improving Care After Inherited Cancer Testing (IMPACT)	2-Mar-2022	Recruiting	34645413	U01CA254832
+clinical_trial	NCT04428905	Self-Management Survivorship Care in Stage I-III Non-small Cell Lung Cancer or Colorectal Cancer	7-Apr-2022	Recruiting	33415649	R01CA249501
+clinical_trial	NCT04867850	Effect of Behavioral Nudges on Serious Illness Conversation Documentation (SPP2)	14-Sep-2021	Recruiting	34563227	P50CA244690
+clinical_trial	NCT04737031	Improving Tobacco Treatment Rates for Outpatient Cancer Patients Who Smoke (SPP1)	11-Jan-2022	Recruiting	34266468	P50CA244690
+clinical_trial	NCT05006482	Geriatric Evaluation and Management With Survivorship Health Education (GEMS) for Older Survivors of Cancer	10-Feb-2022	Not yet recruiting	35292232	R01CA249467
+clinical_trial	NCT04406714	Scaling CRC Screening Through Outreach, Referral, and Engagement (SCORE) (SCORE)	12-May-2021	Recruiting	34620250	UG3CA233251
+clinical_trial	NCT04406714	Scaling CRC Screening Through Outreach, Referral, and Engagement (SCORE) (SCORE)	12-May-2021	Recruiting	34620250	UH3CA233251
+clinical_trial	NCT03264898	Comparative Effectiveness of FITs With Colonoscopy	22-May-2018	Recruiting	33974994	R01CA215034
+clinical_trial	NCT03278340	Using Technology to Scale-Up an Occupational Sun Protection Policy Program (SSW-T)	9-Jul-2021	Enrolling by invitation	32942054	R01CA210259
+clinical_trial	NCT03592771	THRIVE Breast Cancer App Study (THRIVE)	18-Jan-2022	Active, not recruiting	31856812	R01CA218155
+clinical_trial	NCT04427527	Accelerating Colorectal Cancer Screening Through Implementation Science in Appalachia (ACCSIS)	3-May-2021	Recruiting	34011410	UH3CA233282
+clinical_trial	NCT00788671	Levonorgestrel-Releasing Intrauterine System in Treating Patients With Complex Atypical Hyperplasia or Grade I Endometrial Cancer	8-Oct-2021	Active, not recruiting	32805208	P50CA098258
+clinical_trial	NCT02451423	Neoadjuvant Atezolizumab in Localized Bladder Cancer	6-Apr-2022	Recruiting	32497499	U01CA233100
+clinical_trial	NCT02451423	Neoadjuvant Atezolizumab in Localized Bladder Cancer	6-Apr-2022	Recruiting	32497499	U01CA244452
+clinical_trial	NCT02451423	Neoadjuvant Atezolizumab in Localized Bladder Cancer	6-Apr-2022	Recruiting	32497499	R01CA194511
+clinical_trial	NCT03892967	Enhanced, EHR-facilitated Cancer Symptom Control (E2C2) Pragmatic Clinical Trial (E2C2)	31-Jan-2022	Recruiting	32503661	UM1CA233033
+clinical_trial	NCT01727076	Recombinant Interleukin-15 in Treating Patients With Advanced Melanoma, Kidney Cancer, Non-small Cell Lung Cancer, or Squamous Cell Head and Neck Cancer	15-Sep-2017	Completed	29203590	UM1CA154967
+clinical_trial	NCT01727076	Recombinant Interleukin-15 in Treating Patients With Advanced Melanoma, Kidney Cancer, Non-small Cell Lung Cancer, or Squamous Cell Head and Neck Cancer	15-Sep-2017	Completed	30045932	UM1CA154967
+clinical_trial	NCT01628913	Efficacy and Safety of BEZ235 Compared to Everolimus in Patients With Advanced Pancreatic Neuroendocrine Tumors	7-Apr-2016	Terminated	29242283	P50CA174521
+clinical_trial	NCT01576172	Abiraterone Acetate and Prednisone With or Without Veliparib in Treating Patients With Metastatic Castration-Resistant Prostate Cancer	12-Nov-2020	Completed	29261439	P50CA186786
+clinical_trial	NCT02435849	Study of Efficacy and Safety of CTL019 in Pediatric ALL Patients (ELIANA)	31-Mar-2022	Active, not recruiting	29385370	P01CA214278
+clinical_trial	NCT02435849	Study of Efficacy and Safety of CTL019 in Pediatric ALL Patients (ELIANA)	31-Mar-2022	Active, not recruiting	31606419	P01CA214278
+clinical_trial	NCT02435849	Study of Efficacy and Safety of CTL019 in Pediatric ALL Patients (ELIANA)	31-Mar-2022	Active, not recruiting	33496754	P01CA214278
+clinical_trial	NCT01295827	Study of Pembrolizumab (MK-3475) in Participants With Progressive Locally Advanced or Metastatic Carcinoma, Melanoma, or Non-small Cell Lung Carcinoma (P07990/MK-3475-001/KEYNOTE-001) (KEYNOTE-001)	13-Dec-2019	Completed	29486723	R01CA205426
+clinical_trial	NCT02957526	Web-Base App To Improve Aromatase Inhibitor Adherence (AETAPP)	19-Jul-2018	Completed	29492753	R01CA218155
+clinical_trial	NCT00033631	Radiation Therapy in Treating Patients With Stage II Prostate Cancer	29-Jul-2021	Active, not recruiting	29543933	U24CA180803
+clinical_trial	NCT02135406	CART-19 for Multiple Myeloma	13-Feb-2018	Completed	29669947	P01CA214278
+clinical_trial	NCT01578239	A Study Comparing Treatment With 177Lu-DOTA0-Tyr3-Octreotate to Octreotide LAR in Patients With Inoperable, Progressive, Somatostatin Receptor Positive Midgut Carcinoid Tumours (NETTER-1)	4-Apr-2022	Completed	29878866	P50CA174521
+clinical_trial	NCT01578239	A Study Comparing Treatment With 177Lu-DOTA0-Tyr3-Octreotate to Octreotide LAR in Patients With Inoperable, Progressive, Somatostatin Receptor Positive Midgut Carcinoid Tumours (NETTER-1)	4-Apr-2022	Completed	32123969	P50CA174521
+clinical_trial	NCT02546167	CART-BCMA Cells for Multiple Myeloma	4-Aug-2020	Completed	29899820	P01CA214278
+clinical_trial	NCT02546167	CART-BCMA Cells for Multiple Myeloma	4-Aug-2020	Completed	30896447	P01CA214278
+clinical_trial	NCT01626495	Phase I/IIA Study of CART19 Cells for Patients With Chemotherapy Resistant or Refractory CD19+ Leukemia and Lymphoma (Pedi CART19)	23-Mar-2020	Completed	30178481	P01CA214278
+clinical_trial	NCT02303990	RADVAX: A Stratified Phase I Trial of Pembrolizumab With Hypofractionated Radiotherapy in Patients With Advanced and Metastatic Cancers	12-May-2021	Completed	30318516	P01CA210944
+clinical_trial	NCT01302834	Radiation Therapy With Cisplatin or Cetuximab in Treating Patients With Oropharyngeal Cancer	23-Feb-2021	Unknown	30449625	U24CA180803
+clinical_trial	NCT02267603	Pembrolizumab in Treating Patients With Advanced Merkel Cell Cancer	29-Mar-2022	Completed	30726175	UM1CA154967
+clinical_trial	NCT02267603	Pembrolizumab in Treating Patients With Advanced Merkel Cell Cancer	29-Mar-2022	Completed	33879601	UM1CA154967
+clinical_trial	NCT03478397	Evaluation of a mHealth Intervention to Increase Adherence to Triage of Self-collected HPV+ Women (ATICA Project) (ATICA)	6-Apr-2021	Completed	30808379	R01CA218306
+clinical_trial	NCT01623349	Phase I Study of the Oral PI3kinase Inhibitor BKM120 or BYL719 and the Oral PARP Inhibitor Olaparib in Patients With Recurrent Triple Negative Breast Cancer or High Grade Serous Ovarian Cancer	10-Feb-2021	Completed	30880072	R01CA226776
+clinical_trial	NCT01623349	Phase I Study of the Oral PI3kinase Inhibitor BKM120 or BYL719 and the Oral PARP Inhibitor Olaparib in Patients With Recurrent Triple Negative Breast Cancer or High Grade Serous Ovarian Cancer	10-Feb-2021	Completed	32164626	R01CA226776
+clinical_trial	NCT00750269	Stereotactic Body Radiation Therapy in Treating Patients With Stage I Non-Small Cell Lung Cancer	7-May-2019	Unknown	30943123	U24CA180803
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	19-Aug-2021	Active, not recruiting	30954717	U24CA180803
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	19-Aug-2021	Active, not recruiting	31786124	U24CA180803
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	19-Aug-2021	Active, not recruiting	33548339	U10CA180899
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	19-Aug-2021	Active, not recruiting	33548339	U24CA180803
+clinical_trial	NCT01747486	Dose Optimization Trial of CD19 Redirected Autologous T Cells	30-Aug-2019	Completed	31076448	P01CA214278
+clinical_trial	NCT01029366	CART19 to Treat B-Cell Leukemia or Lymphoma That Are Resistant or Refractory to Chemotherapy	26-Jun-2019	Completed	31076448	P01CA214278
+clinical_trial	NCT01029366	CART19 to Treat B-Cell Leukemia or Lymphoma That Are Resistant or Refractory to Chemotherapy	26-Jun-2019	Completed	31815579	P01CA214278
+clinical_trial	NCT01821729	Proton w/FOLFIRINOX-Losartan for Pancreatic Cancer	25-Sep-2020	Active, not recruiting	31145418	R01CA208205
+clinical_trial	NCT01821729	Proton w/FOLFIRINOX-Losartan for Pancreatic Cancer	25-Sep-2020	Active, not recruiting	31145418	U01CA224348
+clinical_trial	NCT02595866	Testing the Addition of an Experimental Medication MK-3475 (Pembrolizumab) to Usual Anti-Retroviral Medications in Patients With HIV and Cancer	11-Mar-2022	Recruiting	31154457	UM1CA154967
+clinical_trial	NCT00920621	Randomized Trial: Maternal Vitamin D Supplementation to Prevent Childhood Asthma (VDAART) (VDAART)	9-Mar-2022	Active, not recruiting	31155658	U01CA164973
+clinical_trial	NCT03639350	The Healthy Diet and Lifestyle Study (HDL)	21-Aug-2018	Completed	31226790	U01CA164973
+clinical_trial	NCT01277757	Akt Inhibitor MK2206 in Treating Patients With Advanced Breast Cancer	19-Dec-2018	Completed	31277699	R01CA226776
+clinical_trial	NCT00822120	S0816 Fludeoxyglucose F 18-PET/CT Imaging and Combination Chemotherapy With or Without Additional Chemotherapy and G-CSF in Treating Patients With Stage III or Stage IV Hodgkin Lymphoma	26-Jan-2022	Active, not recruiting	31331918	U24CA180803
+clinical_trial	NCT02243579	Pembrolizumab in Treating Patients With Relapsed or Refractory Stage IB-IVB Mycosis Fungoides or Sezary Syndrome	20-Sep-2019	Completed	31532724	UM1CA154967
+clinical_trial	NCT02243579	Pembrolizumab in Treating Patients With Relapsed or Refractory Stage IB-IVB Mycosis Fungoides or Sezary Syndrome	20-Sep-2019	Completed	34795254	U2CCA233195
+clinical_trial	NCT02243579	Pembrolizumab in Treating Patients With Relapsed or Refractory Stage IB-IVB Mycosis Fungoides or Sezary Syndrome	20-Sep-2019	Completed	34795254	U2CCA233238
+clinical_trial	NCT02243579	Pembrolizumab in Treating Patients With Relapsed or Refractory Stage IB-IVB Mycosis Fungoides or Sezary Syndrome	20-Sep-2019	Completed	34795254	UM1CA154967
+clinical_trial	NCT01522443	Study of Cabozantinib (XL184) Versus Mitoxantrone Plus Prednisone in Men With Previously Treated Symptomatic Castration-resistant Prostate Cancer (COMET-2)	23-May-2018	Terminated	31556911	U01CA233046
+clinical_trial	NCT01522443	Study of Cabozantinib (XL184) Versus Mitoxantrone Plus Prednisone in Men With Previously Treated Symptomatic Castration-resistant Prostate Cancer (COMET-2)	23-May-2018	Terminated	33258687	U01CA233046
+clinical_trial	NCT01522443	Study of Cabozantinib (XL184) Versus Mitoxantrone Plus Prednisone in Men With Previously Treated Symptomatic Castration-resistant Prostate Cancer (COMET-2)	23-May-2018	Terminated	34420143	U01CA233046
+clinical_trial	NCT01343043	A Pilot Study of Genetically Engineered NY-ESO-1 Specific NY-ESO-1&#7580;&#178;&#8309;&#8313;T in HLA-A2+ Patients With Synovial Sarcoma (NY-ESO-1)	30-Jun-2021	Completed	31651363	P01CA214278
+clinical_trial	NCT01307631	Akt Inhibitor MK2206 in Treating Patients With Recurrent or Advanced Endometrial Cancer	11-Feb-2022	Completed	31714586	P50CA098258
+clinical_trial	NCT02030847	Study of Redirected Autologous T Cells Engineered to Contain Anti-CD19 Attached to TCR and 4-1BB Signaling Domains in Patients With Chemotherapy Resistant or Refractory Acute Lymphoblastic Leukemia	30-Aug-2019	Completed	31815579	P01CA214278
+clinical_trial	NCT00533949	High-Dose or Standard-Dose Radiation Therapy and Chemotherapy With or Without Cetuximab in Treating Patients With Newly Diagnosed Stage III Non-Small Cell Lung Cancer That Cannot Be Removed by Surgery	5-Feb-2020	Unknown	31841363	U24CA180803
+clinical_trial	NCT02092324	Ruxolitinib Phosphate in Treating Patients With Chronic Neutrophilic Leukemia or Atypical Chronic Myeloid Leukemia	16-Nov-2020	Completed	31880950	U54CA224019
+clinical_trial	NCT01677910	TELESTAR (Telotristat Etiprate for Somatostatin Analogue Not Adequately Controlled Carcinoid Syndrome)	27-Feb-2018	Completed	32146619	P50CA174521
+clinical_trial	NCT02063659	Telotristat Etiprate for Carcinoid Syndrome Therapy (TELECAST)	26-Feb-2018	Completed	32146619	P50CA174521
+clinical_trial	NCT00002874	Radiation Therapy With or Without Bicalutamide for Recurrent pT3N0 Prostate Cancer After Radical Prostatectomy	3-Mar-2022	Unknown	32215583	P50CA186786
+clinical_trial	NCT02315612	Anti-CD22 Chimeric Receptor T Cells in Pediatric and Young Adults With Recurrent or Refractory CD22-expressing B Cell Malignancies	11-Apr-2022	Recruiting	32286905	U01CA224766
+clinical_trial	NCT01363206	Granulocyte Macrophage-Colony Stimulating Factor and Ipilimumab as Therapy in Melanoma (GIPI)	19-Mar-2020	Completed	32376721	U01CA233100
+clinical_trial	NCT00064129	Ipilimumab and Sargramostim in Treating Patients With Metastatic Prostate Cancer	30-Jul-2020	Completed	32376721	U01CA233100
+clinical_trial	NCT03799432	Collaborative Organizational Approach to Selecting and Tailoring Implementation Strategies (COAST-IS)	8-Jan-2021	Active, not recruiting	32391524	P50CA244431
+clinical_trial	NCT00557193	Combination Chemotherapy With or Without Lestaurtinib in Treating Younger Patients With Newly Diagnosed Acute Lymphoblastic Leukemia	25-Mar-2022	Active, not recruiting	32414848	U01CA232486
+clinical_trial	NCT01454297	Relating Clinical Outcomes in Multiple Myeloma to Personal Assessment of Genetic Profile (CoMMpass)	16-Aug-2018	Active, not recruiting	32471990	U2CCA233303
+clinical_trial	NCT02296684	Immunotherapy With MK-3475 in Surgically Resectable Head and Neck Squamous Cell Carcinoma	30-Aug-2021	Active, not recruiting	32665297	U24CA237719
+clinical_trial	NCT02296684	Immunotherapy With MK-3475 in Surgically Resectable Head and Neck Squamous Cell Carcinoma	30-Aug-2021	Active, not recruiting	32665297	U01CA209936
+clinical_trial	NCT00902044	Her2 Chimeric Antigen Receptor Expressing T Cells in Advanced Sarcoma	30-Dec-2021	Active, not recruiting	32669548	U54CA232568
+clinical_trial	NCT01191060	Study Comparing Conventional Dose Combination RVD to High-Dose Treatment With ASCT in the Initial Myeloma up to 65 Years (IFM/DFCI2009)	18-Apr-2019	Completed	32687451	P01CA155258
+clinical_trial	NCT02180867	Radiation Therapy With or Without Combination Chemotherapy or Pazopanib Before Surgery in Treating Patients With Newly Diagnosed Non-rhabdomyosarcoma Soft Tissue Sarcomas That Can Be Removed by Surgery	11-Apr-2022	Active, not recruiting	32702309	U24CA180803
+clinical_trial	NCT04358276	Technology-Enabled Activation of Skin Cancer Screening for Stem Cell Transplant Survivors and Their Primary Care Providers, TEACH Study	21-Feb-2022	Recruiting	32746799	R01CA249460
+clinical_trial	NCT00500591	Prevalence of Endometrial Abnormalities In Obese Women	25-Feb-2021	Active, not recruiting	32835719	P50CA098258
+clinical_trial	NCT03051659	A Randomized Phase II Study Of Eribulin Mesylate With or Without Pembrolizumab For Metastatic Hormone Receptor Positive Breast Cancer	21-Dec-2021	Active, not recruiting	32880602	R01CA226776
+clinical_trial	NCT03287908	A Study to Assess AMG 701 Montherapy, or in Combination With Pomalidomide, With or Without, Dexamethasone in Subjects With Relapsed or Refractory Multiple Myeloma	18-Mar-2022	Recruiting	32898244	P01CA155258
+clinical_trial	NCT04071366	A Study of Itacitinib for the Prevention of Cytokine Release Syndrome Induced by Immune Effector Cell Therapy	23-Mar-2022	Recruiting	32998963	P01CA214278
+clinical_trial	NCT03837353	A Parallel Arm Phase 1b/2a Study of DKN-01 as Monotherapy or in Combination With Docetaxel for the Treatment of Advanced Prostate Cancer With Elevated DKK1	3-Mar-2022	Recruiting	33015525	U54CA224079
+clinical_trial	NCT04302675	Adapting Motivational Interviewing for Maternal Immunizations (MI4MI) (MI4MI)	26-Jul-2021	Active, not recruiting	33203635	P50CA244688
+clinical_trial	NCT00022737	Combination Chemotherapy With or Without Peripheral Stem Cell Transplant in Treating Children With Acute Lymphoblastic Leukemia	27-Feb-2014	Completed	33242441	U01CA232486
+clinical_trial	NCT00287105	Safety and Efficacy of Imatinib Added to Chemotherapy in Treatment of Ph+ Acute Lymphoblastic Leukemia in Children (ESPHALL)	20-Oct-2017	Completed	33242441	U01CA232486
+clinical_trial	NCT00720109	Dasatinib and Combination Chemotherapy in Treating Young Patients With Newly Diagnosed Acute Lymphoblastic Leukemia	13-Apr-2020	Completed	33242441	U01CA232486
+clinical_trial	NCT01460160	Pediatric Philadelphia Positive Acute Lymphoblastic Leukemia	8-Dec-2021	Completed	33242441	U01CA232486
+clinical_trial	NCT01423747	Allogeneic Stem Cell Transplantation in Children and Adolescents With Acute Lymphoblastic Leukaemia	26-Jun-2015	Unknown	33242441	U01CA232486
+clinical_trial	NCT01423500	ALL-SCT BFM International- HSCT in Children and Adolescents With ALL (ALL-SCT-BFMi)	26-Jun-2015	Unknown	33242441	U01CA232486
+clinical_trial	NCT01949129	Allogeneic Stem Cell Transplantation for Children and Adolescents With Acute Lymphoblastic Leukaemia	1-Oct-2020	Recruiting	33242441	U01CA232486
+clinical_trial	NCT01117441	International Collaborative Treatment Protocol For Children And Adolescents With Acute Lymphoblastic Leukemia	20-Oct-2020	Active, not recruiting	33242441	U01CA232486
+clinical_trial	NCT02066181	Sorafenib Tosylate in Treating Patients With Desmoid Tumors or Aggressive Fibromatosis	22-Mar-2022	Active, not recruiting	33258687	U01CA233046
+clinical_trial	NCT02066181	Sorafenib Tosylate in Treating Patients With Desmoid Tumors or Aggressive Fibromatosis	22-Mar-2022	Active, not recruiting	34420143	U01CA233046
+clinical_trial	NCT02906371	Study of the Tocilizumab Optimization Timing for CART19 Associated Cytokine Release Syndrome	2-Jul-2021	Completed	33417474	P01CA214278
+clinical_trial	NCT01970358	A Phase I Study With a Personalized NeoAntigen Cancer Vaccine in Melanoma	9-Dec-2020	Completed	33479501	U24CA224331
+clinical_trial	NCT02228096	Study of Efficacy and Safety of CTL019 in Pediatric ALL Patients (ENSIGN)	23-Nov-2020	Completed	33496754	P01CA214278
+clinical_trial	NCT02058706	LHRH Analogue Therapy With Enzalutamide or Bicalutamide in Treating Patients With Metastatic Hormone Sensitive Prostate Cancer	3-Mar-2021	Active, not recruiting	33496795	P50CA186786
+clinical_trial	NCT02254278	Reduced-Dose Intensity-Modulated Radiation Therapy With or Without Cisplatin in Treating Patients With Advanced Oropharyngeal Cancer	11-Mar-2022	Active, not recruiting	33507809	U24CA180803
+clinical_trial	NCT02136134	Addition of Daratumumab to Combination of Bortezomib and Dexamethasone in Participants With Relapsed or Refractory Multiple Myeloma	25-Mar-2022	Active, not recruiting	33513030	P01CA155258
+clinical_trial	NCT02076009	A Study Comparing Daratumumab, Lenalidomide, and Dexamethasone With Lenalidomide and Dexamethasone in Relapsed or Refractory Multiple Myeloma	25-Mar-2022	Active, not recruiting	33513030	P01CA155258
+clinical_trial	NCT03224520	Smoker-to-Smoker (S2S) Peer Marketing and Messaging to Disseminate Tobacco Interventions	26-Mar-2021	Completed	33571687	P50CA244693
+clinical_trial	NCT01497808	RADVAX&#8482;: A STRATIFIED PHASE I/II DOSE ESCALATION TRIAL OF HYPOFRACTIONATED RADIOTHERAPY FOLLOWED BY IPILIMUMAB IN METASTATIC MELANOMA	10-Aug-2021	Completed	33643689	P01CA210944
+clinical_trial	NCT01822509	Ipilimumab or Nivolumab in Treating Patients With Relapsed Hematologic Malignancies After Donor Stem Cell Transplant	24-Jun-2021	Completed	33720354	U01DK124165
+clinical_trial	NCT01822509	Ipilimumab or Nivolumab in Treating Patients With Relapsed Hematologic Malignancies After Donor Stem Cell Transplant	24-Jun-2021	Completed	33720354	U24CA224316
+clinical_trial	NCT01822509	Ipilimumab or Nivolumab in Treating Patients With Relapsed Hematologic Malignancies After Donor Stem Cell Transplant	24-Jun-2021	Completed	33720354	U24CA224319
+clinical_trial	NCT01822509	Ipilimumab or Nivolumab in Treating Patients With Relapsed Hematologic Malignancies After Donor Stem Cell Transplant	24-Jun-2021	Completed	33720354	U24CA224331
+clinical_trial	NCT02206334	Stereotactic Body Radiation Therapy in Treating Patients With Metastatic Breast Cancer, Non-small Cell Lung Cancer, or Prostate Cancer	2-Mar-2022	Active, not recruiting	33885704	U24CA180803
+clinical_trial	NCT02588456	Pilot Study of Autologous Anti-CD22 Chimeric Antigen Receptor Redirected T Cells In Patients With Chemotherapy Resistant Or Refractory Acute Lymphoblastic Leukemia	12-Jan-2018	Terminated	33888899	P01CA214278
+clinical_trial	NCT02650414	CD22 Redirected Autologous T Cells for ALL	21-Jan-2022	Recruiting	33888899	P01CA214278
+clinical_trial	NCT01804465	Sipuleucel-T With Immediate vs. Delayed Cytotoxic T-Lymphocyte-Associated Protein 4 (CTLA-4) Blockade for Prostate Cancer	18-Aug-2021	Completed	33986125	U01CA233100
+clinical_trial	NCT01804465	Sipuleucel-T With Immediate vs. Delayed Cytotoxic T-Lymphocyte-Associated Protein 4 (CTLA-4) Blockade for Prostate Cancer	18-Aug-2021	Completed	33986125	U01CA244452
+clinical_trial	NCT02501096	A Trial of Lenvatinib (E7080) Plus Pembrolizumab in Participants With Selected Solid Tumors	7-Mar-2022	Active, not recruiting	34039647	R01CA205426
+clinical_trial	NCT03985852	Broadening the Reach, Impact, and Delivery of Genetic Services (BRIDGE)	27-Aug-2021	Enrolling by invitation	34078380	U01CA232826
+clinical_trial	NCT00085735	Comparison of Radiation Therapy Regimens in Combination With Chemotherapy in Treating Young Patients With Newly Diagnosed Standard-Risk Medulloblastoma	2-Mar-2022	Active, not recruiting	34110925	U10CA180899
+clinical_trial	NCT00085735	Comparison of Radiation Therapy Regimens in Combination With Chemotherapy in Treating Young Patients With Newly Diagnosed Standard-Risk Medulloblastoma	2-Mar-2022	Active, not recruiting	34110925	U24CA196173
+clinical_trial	NCT00085735	Comparison of Radiation Therapy Regimens in Combination With Chemotherapy in Treating Young Patients With Newly Diagnosed Standard-Risk Medulloblastoma	2-Mar-2022	Active, not recruiting	34110925	U24CA180803
+clinical_trial	NCT03607617	ASCEND: ApproacheS to CHC ImplEmeNtation of SDH Data Collection and Action (ASCEND)	15-Jun-2021	Active, not recruiting	34174834	P50CA244289
+clinical_trial	NCT02054741	Geriatric Assessment Intervention for Reducing Toxicity in Older Patients With Advanced Cancer	7-Apr-2022	Completed	34272204	U01CA233167
+clinical_trial	NCT02054741	Geriatric Assessment Intervention for Reducing Toxicity in Older Patients With Advanced Cancer	7-Apr-2022	Completed	34741815	U01CA233167
+clinical_trial	NCT03233854	CD19/CD22 Chimeric Antigen Receptor(CAR) T Cells in Adults With Recurrent/Refractory B Cell Malignancies	21-Feb-2022	Recruiting	34312556	U54CA232568
+clinical_trial	NCT02186847	Chemotherapy and Radiation Therapy With or Without Metformin Hydrochloride in Treating Patients With Stage III Non-small Cell Lung Cancer	23-Jun-2020	Active, not recruiting	34323922	U24CA180803
+clinical_trial	NCT03971799	Study of Anti-CD33 Chimeric Antigen Receptor-Expressing T Cells (CD33CART) in Children and Young Adults With Relapsed/Refractory Acute Myeloid Leukemia	14-Oct-2021	Recruiting	34531250	U01CA232486
+clinical_trial	NCT02478931	Study of Personalized Cancer Therapy to Determine Response and Toxicity (UCSD_PREDICT)	5-Apr-2021	Recruiting	34641956	U01CA217885
+clinical_trial	NCT02355262	CATCH-UP Intervention in Increasing Cancer Screening and Prevention Care in Uninsured Patients at Community Health Centers	19-Aug-2020	Completed	34717616	P50CA244289
+clinical_trial	NCT04258813	Onco-primary Care Networking to Support TEAM-based Care (ONE TEAM)	21-Mar-2022	Recruiting	34794388	R01CA249568
+clinical_trial	NCT00980460	Risk-Based Therapy in Treating Younger Patients With Newly Diagnosed Liver Cancer	20-Jan-2022	Active, not recruiting	34874751	U10CA180899
+clinical_trial	NCT00980460	Risk-Based Therapy in Treating Younger Patients With Newly Diagnosed Liver Cancer	20-Jan-2022	Active, not recruiting	34874751	U24CA180803
+clinical_trial	NCT02888743	Durvalumab and Tremelimumab With or Without High or Low-Dose Radiation Therapy in Treating Patients With Metastatic Colorectal or Non-small Cell Lung Cancer	6-Jan-2022	Active, not recruiting	35033226	U24CA224316
+clinical_trial	NCT02888743	Durvalumab and Tremelimumab With or Without High or Low-Dose Radiation Therapy in Treating Patients With Metastatic Colorectal or Non-small Cell Lung Cancer	6-Jan-2022	Active, not recruiting	35033226	U24CA224331
+clinical_trial	NCT01514201	Veliparib, Radiation Therapy, and Temozolomide in Treating Younger Patients With Newly Diagnosed Diffuse Pontine Gliomas	13-Aug-2019	Completed	32009149	UM1CA081457
+clinical_trial	NCT02847130	Identifying, Understanding, and Overcoming Barriers to the Use of Clinical Practice Guidelines in Pediatric Oncology	5-Sep-2021	Active, not recruiting	34530933	UG1CA189955
+clinical_trial	NCT04239573	Comparing Two Methods to Follow Patients With Pancreatic Cysts	3-Jan-2022	Recruiting	32920242	UG1CA189828
+clinical_trial	NCT02296684	Immunotherapy With MK-3475 in Surgically Resectable Head and Neck Squamous Cell Carcinoma	28-Apr-2022	Completed	32665297	U24CA237719
+clinical_trial	NCT02296684	Immunotherapy With MK-3475 in Surgically Resectable Head and Neck Squamous Cell Carcinoma	28-Apr-2022	Completed	32665297	U01CA209936
+clinical_trial	NCT01642251	Cisplatin and Etoposide With or Without Veliparib in Treating Patients With Extensive Stage Small Cell Lung Cancer	5-Feb-2019	Completed	32860331	UG1CA189828
+clinical_trial	NCT01863550	Bortezomib or Carfilzomib With Lenalidomide and Dexamethasone in Treating Patients With Newly Diagnosed Multiple Myeloma	3-Jan-2022	Active, not recruiting	32866432	UG1CA189828
+clinical_trial	NCT03257631	A Study of Pomalidomide Monotherapy for Children and Young Adults With Recurrent or Progressive Primary Brain Tumors	3-May-2022	Active, not recruiting	33025730	UM1CA081457
+clinical_trial	NCT01606878	Crizotinib and Combination Chemotherapy in Treating Younger Patients With Relapsed or Refractory Solid Tumors or Anaplastic Large Cell Lymphoma	26-Feb-2019	Completed	33095287	UM1CA228823
+clinical_trial	NCT01503515	Caspofungin Acetate, Fluconazole, or Voriconazole in Preventing Fungal Infections in Patients Following Donor Stem Cell Transplant	31-Jan-2022	Completed	33136159	UG1CA189955
+clinical_trial	NCT01503515	Caspofungin Acetate, Fluconazole, or Voriconazole in Preventing Fungal Infections in Patients Following Donor Stem Cell Transplant	31-Jan-2022	Completed	33136159	U10CA180899
+clinical_trial	NCT01190930	Risk-Adapted Chemotherapy in Treating Younger Patients With Newly Diagnosed Standard-Risk Acute Lymphoblastic Leukemia or Localized B-Lineage Lymphoblastic Lymphoma	8-Jun-2021	Active, not recruiting	33411585	U10CA180899
+clinical_trial	NCT00025259	Chemotherapy With or Without Additional Chemotherapy and/or Radiation Therapy in Treating Children With Newly Diagnosed Hodgkin's Disease	12-Apr-2017	Completed	33512412	U10CA180899
+clinical_trial	NCT00025259	Chemotherapy With or Without Additional Chemotherapy and/or Radiation Therapy in Treating Children With Newly Diagnosed Hodgkin's Disease	12-Apr-2017	Completed	34662378	U10CA180899
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	28-Apr-2022	Completed	33548339	U10CA180899
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	28-Apr-2022	Completed	33548339	U24CA180803
+clinical_trial	NCT00346164	Observation, Radiation Therapy, Combination Chemotherapy, and/or Surgery in Treating Young Patients With Soft Tissue Sarcoma	28-Apr-2022	Completed	34623899	U10CA180899
+clinical_trial	NCT00939770	Crizotinib in Treating Younger Patients With Relapsed or Refractory Solid Tumors or Anaplastic Large Cell Lymphoma	9-Jun-2020	Completed	33568345	UM1CA228823
+clinical_trial	NCT01979536	Brentuximab Vedotin or Crizotinib and Combination Chemotherapy in Treating Patients With Newly Diagnosed Stage II-IV Anaplastic Large Cell Lymphoma	24-Feb-2022	Active, not recruiting	33684925	U10CA180899
+clinical_trial	NCT02808650	Prexasertib in Treating Pediatric Patients With Recurrent or Refractory Solid Tumors	15-Apr-2021	Completed	33881209	UM1CA228823
+clinical_trial	NCT03126916	Iobenguane I-131 or Crizotinib and Standard Therapy in Treating Younger Patients With Newly-Diagnosed High-Risk Neuroblastoma or Ganglioneuroblastoma	25-Aug-2021	Recruiting	34028986	U10CA180899
+clinical_trial	NCT01175356	Induction Therapy Including 131 I-MIBG and Chemotherapy in Treating Patients With Newly Diagnosed High-Risk Neuroblastoma Undergoing Stem Cell Transplant, Radiation Therapy, and Maintenance Therapy With Isotretinoin	7-Mar-2022	Active, not recruiting	34028986	U10CA180899
+clinical_trial	NCT01407757	Study of Gemtuzumab Ozogamicin Therapy in DNA Samples From Patients With Acute Myeloid Leukemia Treated on COG-AAML0531	19-May-2016	Completed	34048275	U10CA180899
+clinical_trial	NCT02445391	Platinum Based Chemotherapy or Capecitabine in Treating Patients With Residual Triple-Negative Basal-Like Breast Cancer Following Neoadjuvant Chemotherapy	21-May-2020	Recruiting	34092112	UG1CA189828
+clinical_trial	NCT00392327	Chemotherapy and Radiation Therapy in Treating Young Patients With Newly Diagnosed, Previously Untreated, High-Risk Medulloblastoma/PNET	6-Jan-2022	Active, not recruiting	34292305	U10CA180899
+clinical_trial	NCT02444884	MLN8237 to Treat Children With Relapsed/Refractory Solid Tumors	9-Feb-2016	Completed	34435684	U10CA180899
+clinical_trial	NCT01154816	Alisertib in Treating Young Patients With Recurrent or Refractory Solid Tumors or Leukemia	13-May-2020	Completed	34435684	U10CA180899
+clinical_trial	NCT02180867	Radiation Therapy With or Without Combination Chemotherapy or Pazopanib Before Surgery in Treating Patients With Newly Diagnosed Non-rhabdomyosarcoma Soft Tissue Sarcomas That Can Be Removed by Surgery	29-Apr-2022	Active, not recruiting	34515544	U10CA180899
+clinical_trial	NCT01516567	Intergroup Trial for Children or Adolescents With Primary Mediastinal Large B-Cell Lymphoma: DA-EPOCH-Rituximab Evaluation	18-Mar-2021	Active, not recruiting	34570655	U10CA180899
+clinical_trial	NCT00372593	Combination Chemotherapy With or Without Gemtuzumab in Treating Young Patients With Newly Diagnosed Acute Myeloid Leukemia	24-Mar-2021	Completed	34596937	U10CA180899
+clinical_trial	NCT01371981	Bortezomib and Sorafenib Tosylate in Treating Patients With Newly Diagnosed Acute Myeloid Leukemia	29-Apr-2022	Active, not recruiting	34596937	U10CA180899
+clinical_trial	NCT01371981	Bortezomib and Sorafenib Tosylate in Treating Patients With Newly Diagnosed Acute Myeloid Leukemia	29-Apr-2022	Active, not recruiting	34855461	U10CA180899
+clinical_trial	NCT01231906	Combination Chemotherapy in Treating Patients With Non-Metastatic Extracranial Ewing Sarcoma	23-May-2022	Active, not recruiting	34652968	U10CA180899
+clinical_trial	NCT02339740	Tretinoin and Arsenic Trioxide in Treating Patients With Untreated Acute Promyelocytic Leukemia	24-Jan-2022	Active, not recruiting	34762093	U10CA180899
+clinical_trial	NCT02339740	Tretinoin and Arsenic Trioxide in Treating Patients With Untreated Acute Promyelocytic Leukemia	24-Jan-2022	Active, not recruiting	34762093	U24CA196173
+clinical_trial	NCT00980460	Risk-Based Therapy in Treating Younger Patients With Newly Diagnosed Liver Cancer	29-Apr-2022	Active, not recruiting	34874751	U10CA180899
+clinical_trial	NCT00980460	Risk-Based Therapy in Treating Younger Patients With Newly Diagnosed Liver Cancer	29-Apr-2022	Active, not recruiting	34874751	U24CA180803
+clinical_trial	NCT02823652	Pre-Test Genetic Education and Remote Genetic Counseling in Communicating Tumor Profiling Results to Patients With Advanced Cancer	2-Aug-2021	Completed	34890045	UG1CA189828
+clinical_trial	NCT02981628	Inotuzumab Ozogamicin in Treating Younger Patients With B-Lymphoblastic Lymphoma or Relapsed or Refractory CD22 Positive B Acute Lymphoblastic Leukemia	29-Mar-2022	Active, not recruiting	35007127	U10CA180899
+clinical_trial	NCT02981628	Inotuzumab Ozogamicin in Treating Younger Patients With B-Lymphoblastic Lymphoma or Relapsed or Refractory CD22 Positive B Acute Lymphoblastic Leukemia	29-Mar-2022	Active, not recruiting	35007127	U24CA196173
+clinical_trial	NCT00945009	Combination Chemotherapy and Surgery in Treating Young Patients With Wilms Tumor	25-Mar-2022	Active, not recruiting	35072864	U10CA180899
+clinical_trial	NCT00945009	Combination Chemotherapy and Surgery in Treating Young Patients With Wilms Tumor	25-Mar-2022	Active, not recruiting	35072864	U24CA196173
+clinical_trial	NCT00433511	Doxorubicin Hydrochloride, Cyclophosphamide, and Paclitaxel With or Without Bevacizumab in Treating Patients With Lymph Node-Positive or High-Risk, Lymph Node-Negative Breast Cancer	18-May-2022	Active, not recruiting	35226083	UG1CA189828

--- a/digest_data/digest_dbgap.tsv
+++ b/digest_data/digest_dbgap.tsv
@@ -1,0 +1,7 @@
+type	accession	title	release_date	publication_id	queried_project_id
+dbgap	phs001041.v1.p1	enetic Basis for Clinical Response to CTLA-4 Blockade in Melanoma	10-Jun-2016	29132144	R01CA205426
+dbgap	phs000980.v1.p1	utational Landscape Determines Sensitivity to PD-1 Blockade in Non-Small Cell Lung Cancer	19-Nov-2015	29132144	R01CA205426
+dbgap	phs001577.v1.p1	tructural Alterations Driving Castration-Resistant Prostate Cancer Revealed by Linked-Read Genome Sequencing	12-Sep-2018	29610475	U54CA224079
+dbgap	phs000450.v3.p1	olecular Subtypes of Diffuse Large B-cell Lymphoma are Associated with Distinct Pathogenic Mechanisms and Outcomes	11-Oct-2018	29713087	U24CA210999
+dbgap	phs001623.v1.p1	enomic Analysis of Head and Neck Cancers	23-Oct-2018	30134176	U01CA209936
+dbgap	phs001234.v1.p1	argeted Sequencing of Primary ER-positive Breast Tumors Treated with 5 Years of Tamoxifen	16-Oct-2018	30181556	U01CA209936

--- a/digest_data/digest_geo.tsv
+++ b/digest_data/digest_geo.tsv
@@ -1,0 +1,781 @@
+type	accession	title	status	submission_date	last_update_date	publication_id	queried_project_id
+geo	GSE94041	TOP2 synergizes with BAF chromatin remodeling for both resolutions and formation of facultative heterochromatin	Public on Mar 01, 2017	25-Jan-2017	15-May-2019	28250416	R01CA163915
+geo	GSE94040	esBAF chromatin remodeling complexes promote spacing of nucleosomes flanking pluripotency factor binding sites	Public on Mar 01, 2017	25-Jan-2017	15-May-2019	28250416	R01CA163915
+geo	GSE94039	TOP2 synergizes with BAF chromatin remodeling for resolution of facultative heterochromatin	Public on Mar 01, 2017	25-Jan-2017	15-May-2019	28250416	R01CA163915
+geo	GSE88997	Reconstituting development of pancreatic intraepithelial neoplasia from primary human pancreas duct cells	Public on Mar 14, 2017	20-Oct-2016	15-May-2019	28272465	R01CA211927
+geo	GSE87164	Gene expression in MMTV-PyMT whole tumor, CD3+ lymphocytes or CD11b+ myeloid cells with and without Class IIa HDAC inhibitor treatment	Public on Mar 08, 2017	21-Sep-2016	4-Mar-2019	28273064	R01CA205967
+geo	GSE87163	MMTV-PyMT whole tumor gene expression with and without Class IIa HDAC inhibitor treatment	Public on Mar 08, 2017	21-Sep-2016	4-Mar-2019	28273064	R01CA205967
+geo	GSE76659	Differential gene expression in either CD3+ lymphocytes or CD11b+ myeloid cells due to Class IIa HDAC inhibitor treatment	Public on Mar 08, 2017	7-Jan-2016	4-Mar-2019	28273064	R01CA205967
+geo	GSE96775	Chromatin-associated protein interactions drive megadomain formation in NUT midline carcinoma	Public on Aug 22, 2017	17-Mar-2017	15-May-2019	28484033	R01CA124633
+geo	GSE93395	Gene expression profile of human multiple myeloma cell line MM.1S after knockdown of KDM6B	Public on May 01, 2017	10-Jan-2017	15-May-2019	28487543	P01CA155258
+geo	GSE86147	Gene expression profiles of MM.1S cells after knockdown of HDAC3 or DNMT1	Public on Jun 01, 2017	28-Aug-2016	25-Mar-2019	28490812	P01CA155258
+geo	GSE98705	Analysis of gene expression in p53-null cell types following deletion of Mdm2	Public on Sep 06, 2017	9-May-2017	25-Jul-2021	28576884	R01CA181204
+geo	GSE39754	Gene Expression profiling of Multiple Myeloma	Public on Sep 10, 2012	30-Jul-2012	1-Aug-2019	28581522	P01CA155258
+geo	GSE83503	Key transcription factors altered in multiple myeloma patients revealed by logic programming approach combining gene expression pro ling and regulatory networks	Public on Sep 20, 2017	20-Jun-2016	18-Feb-2019	28835615	P01CA155258
+geo	GSE83088	Transcription profile of WT and LKB1 (encoded by the gene Stk11)-deficient Treg cells	Public on Aug 29, 2017	7-Jun-2016	21-Feb-2018	28847007	R01CA221290
+geo	GSE100317	Effects of inhibition of topoisomerase I or HSP90 in primary melanoma cell lines	Public on Oct 04, 2017	21-Jun-2017	25-Jul-2021	28878208	R01CA187076
+geo	GSE99381	AR-independent prostate cancer is sustained through FGF signaling	Public on Oct 09, 2017	29-May-2017	25-Jul-2021	29017058	U54CA224079
+geo	GSE91061	Molecular portraits of tumor mutational and micro-environmental sculpting by immune checkpoint blockade therapy	Public on Jan 23, 2018	8-Dec-2016	15-May-2019	29033130	R01CA205426
+geo	GSE89129	Suppression of adaptive responses to targeted cancer therapy by transcriptional repression	Public on Oct 23, 2017	24-Oct-2016	15-May-2019	29054992	P01CA154303
+geo	GSE89128	Suppression of adaptive responses to targeted cancer therapy by transcriptional repression [ChIP-seq]	Public on Oct 23, 2017	24-Oct-2016	15-May-2019	29054992	P01CA154303
+geo	GSE89127	Suppression of adaptive responses to targeted cancer therapy by transcriptional repression [RNA-seq]	Public on Oct 23, 2017	24-Oct-2016	15-May-2019	29054992	P01CA154303
+geo	GSE51906	Gene expression profiling of oncogenic NRAS driven mouse melanomas that have developed resistance to NRAS withdrawal	Public on Oct 31, 2014	30-Oct-2013	19-Jul-2019	29076949	R01CA121118
+geo	GSE73628	RNA-Seq data for AKT, BAD, ERBB2, IGF1R, RAF1 and ERK1 over-expressed samples with twelve green fluorescent protein control samples using human mammary epithelial cells	Public on Jan 01, 2017	30-Sep-2015	24-May-2019	29093439	U54CA209978
+geo	GSE89477	Single-cell profiling of tumor infiltrating T cells	Public on Nov 26, 2017	3-Nov-2016	15-May-2019	29101163	P01CA154303
+geo	GSE85559	Expression profiling and occupancy after knockdown or over-expression of HFN1A or HNF4G in prostate cancer cells	Public on Nov 01, 2017	12-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE85558	HNF4G, AR, FOXA1, H3K4me1, H3K27acetyl binding sites upon knockdown and overexpression of HNF4G in 22Rv1 and LNCaP prostate cancer cells respectively	Public on Nov 01, 2017	12-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE85557	Expression profile of LNCaP/AR cells with or without HNF4G expression grown for long term in charcoal stripped-serum (CSS) media	Public on Nov 01, 2017	12-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE85556	Expression profile of HNF1A knockdown and overexpression in 22RV1 and LNCaP cells respectively	Public on Nov 01, 2017	12-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE85244	Gene expression profile of LNCaP prostate cancer cells with exogenous HNF4G expression	Public on Nov 01, 2017	5-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE85242	Gene expression profile of doxycycline inducible shHNF4G hairpins in 22RV1 prostate cancer cells	Public on Nov 01, 2017	5-Aug-2016	24-May-2019	29153843	U54CA224079
+geo	GSE104831	Transcriptome profiling reveals anti-inflammatory activity of miR-29b in multiple myeloma associated dendritic cells	Public on Oct 10, 2018	11-Oct-2017	25-Jul-2021	29158557	P01CA155258
+geo	GSE104294	Osteoblasts remotely supply lung tumors with cancer-promoting SiglecFhigh neutrophils	Public on Dec 08, 2017	26-Sep-2017	25-Jul-2021	29191879	R01AI084880
+geo	GSE105437	Expression data from endothelial cell	Public on Oct 21, 2017	20-Oct-2017	25-Jul-2021	29212026	P50CA098258
+geo	GSE106519	Expression data from human endothelial cells co-cultured with cancer associated fibroblasts	Public on Feb 14, 2018	3-Nov-2017	16-Oct-2018	29251630	P50CA098258
+geo	GSE131674	A major chromatin regulator determines resistance of tumor cells to T cell–mediated killing	Public on May 22, 2019	22-May-2019	25-May-2019	29301958	U24CA224316
+geo	GSE107670	A Major Chromatin Regulator Determines Resistance of Tumor Cells to T cell Mediated Killing	Public on Jan 08, 2018	4-Dec-2017	15-May-2019	29301958	U24CA224316
+geo	GSE107078	Peptidomimetic blockade of MYB in acute myeloid leukemia [H3K27ac ChIP-seq]	Public on Feb 23, 2018	17-Nov-2017	15-May-2019	29317678	R01CA204396
+geo	GSE94242	Peptidomimetic blockade of MYB in acute myeloid leukemia	Public on Feb 23, 2018	27-Jan-2017	15-May-2019	29317678	R01CA204396
+geo	GSE94241	Peptidomimetic blockade of MYB in acute myeloid leukemia [RNA-seq]	Public on Feb 23, 2018	27-Jan-2017	15-May-2019	29317678	R01CA204396
+geo	GSE94240	Peptidomimetic blockade of MYB in acute myeloid leukemia [MYB ChIP-seq]	Public on Feb 23, 2018	27-Jan-2017	15-May-2019	29317678	R01CA204396
+geo	GSE105799	Analysis of genome-wide accessibility following acute deletion of Ring1b in mouse embryonic stem cells [ATAC-seq]	Public on Oct 23, 2017	23-Oct-2017	15-May-2019	29323272	R01CA163915
+geo	GSE98605	Dominant-negative SMARCA4 mutants alter the accessibility landscape of tissue-unrestricted enhancers	Public on Oct 20, 2017	5-May-2017	25-Jul-2021	29323272	R01CA163915
+geo	GSE98604	Effects of dominant-negative G784E Smarca4 mutation on enhancer marks and factors in mouse embryonic stem cells [ChIP-seq]	Public on Oct 22, 2017	5-May-2017	25-Jul-2021	29323272	R01CA163915
+geo	GSE98486	Effects of dominant-negative Smarca4 mutations on the DNA accessibility landscape [ATAC-seq]	Public on Oct 22, 2017	2-May-2017	25-Jul-2021	29323272	R01CA163915
+geo	GSE98469	Transcriptional effects of dominant-negative G784E Smarca4 mutation in mouse embryonic stem cells [RNA-seq]	Public on Oct 22, 2017	2-May-2017	25-Jul-2021	29323272	R01CA163915
+geo	GSE102527	Rheostatic Chromatin Control of Promiscuous Transcription by Aire and Brg1	Public on Dec 06, 2017	11-Aug-2017	25-Jul-2021	29335648	R01CA163915
+geo	GSE102526	Rheostatic Chromatin Control of Promiscuous Transcription by Aire and Brg1 [ATAC-Seq]	Public on Dec 06, 2017	11-Aug-2017	15-May-2019	29335648	R01CA163915
+geo	GSE102525	Rheostatic Chromatin Control of Promiscuous Transcription by Aire and Brg1 [Affymetrix]	Public on Dec 13, 2017	11-Aug-2017	25-Jul-2021	29335648	R01CA163915
+geo	GSE80443	ETV1 binding sites in GIST and Melanoma cells	Public on Apr 15, 2018	19-Apr-2016	15-May-2019	29360641	U54CA224079
+geo	GSE80352	Transcriptional effect of ETV1 knockdown in melanoma cells	Public on Apr 15, 2018	15-Apr-2016	15-May-2019	29360641	U54CA224079
+geo	GSE80313	Role of COP1 on MAP kinase transcriptional output in melanoma	Public on Apr 15, 2018	14-Apr-2016	15-May-2019	29360641	U54CA224079
+geo	GSE80305	Role of COP1 on MAP kinase transcriptional output in gastrointestinal stromal tumor	Public on Apr 15, 2018	14-Apr-2016	15-May-2019	29360641	U54CA224079
+geo	GSE100538	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ChIP-seq Th-MYCN]	Public on Jan 30, 2018	27-Jun-2017	25-Jul-2021	29379199	P01CA155258
+geo	GSE80154	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma	Public on Jan 29, 2018	11-Apr-2016	25-Jul-2021	29379199	P01CA155258
+geo	GSE80153	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [RNA-seq]	Public on Jan 30, 2018	11-Apr-2016	15-May-2019	29379199	P01CA155258
+geo	GSE80152	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ATAC-seq]	Public on Jan 30, 2018	11-Apr-2016	15-May-2019	29379199	P01CA155258
+geo	GSE80151	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ChIP-seq]	Public on Jan 30, 2018	11-Apr-2016	25-Jul-2021	29379199	P01CA155258
+geo	GSE80150	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ChIP_RX]	Public on Jan 30, 2018	11-Apr-2016	15-May-2019	29379199	P01CA155258
+geo	GSE80149	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ARRAY]	Public on Jan 30, 2018	11-Apr-2016	31-Jan-2018	29379199	P01CA155258
+geo	GSE107073	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia	Public on Jul 23, 2018	17-Nov-2017	15-May-2019	29431698	R01CA204396
+geo	GSE107072	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia [ATAC-seq]	Public on Jul 23, 2018	17-Nov-2017	15-May-2019	29431698	R01CA204396
+geo	GSE107071	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia [inhibitor MRT199665]	Public on Jul 23, 2018	17-Nov-2017	15-May-2019	29431698	R01CA204396
+geo	GSE94453	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia [mutant MEF2C]	Public on Jul 23, 2018	3-Feb-2017	15-May-2019	29431698	R01CA204396
+geo	GSE108524	Targeting the cMET pathway augments radiation response without adverse effect on hearing in NF2 schwannoma models	Public on Jun 26, 2018	26-Dec-2017	29-Oct-2018	29440379	R01CA208205
+geo	GSE108524	Targeting the cMET pathway augments radiation response without adverse effect on hearing in NF2 schwannoma models	Public on Jun 26, 2018	26-Dec-2017	29-Oct-2018	29440379	U01CA224348
+geo	GSE97265	High-efficiency RNA-based reprogramming of human primary fibroblasts	Public on Feb 27, 2018	31-Mar-2017	15-May-2019	29467427	R01AI124487
+geo	GSE108615	A non-catalytic function of SETD1A regulates Cyclin K and the DNA damage response	Public on Feb 01, 2018	28-Dec-2017	25-Mar-2019	29474905	R01CA204396
+geo	GSE87324	BRCA1/RNApII regulation in Ewing's sarcoma (ChIP-seq)	Public on Mar 09, 2018	23-Sep-2016	25-Jul-2021	29513652	R01CA204915
+geo	GSE68847	BRCA1, R-loops and Recombination defects in Ewing's sarcoma	Public on Mar 09, 2018	13-May-2015	25-Jul-2021	29513652	R01CA204915
+geo	GSE68845	BRCA1, R-loops and Recombination defects in Ewing's sarcoma (DRIP-seq)	Public on Mar 09, 2018	13-May-2015	15-May-2019	29513652	R01CA204915
+geo	GSE68836	BRCA1, R-loops and Recombination defects in Ewing's sarcoma (RNA-seq)	Public on Mar 09, 2018	13-May-2015	15-May-2019	29513652	R01CA204915
+geo	GSE109209	mRNA profiles in PAF KO intestinal adenoma	Public on Feb 15, 2018	15-Jan-2018	19-Mar-2019	29533773	P50CA098258
+geo	GSE100465	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin	Public on Dec 31, 2017	26-Jun-2017	25-Jul-2021	29535300	R01CA204136
+geo	GSE100464	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [RNA-seq]	Public on Dec 31, 2017	26-Jun-2017	25-Jul-2021	29535300	R01CA204136
+geo	GSE100463	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [H3.3 ChIP]	Public on Dec 31, 2017	26-Jun-2017	15-May-2019	29535300	R01CA204136
+geo	GSE100462	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [Atrx ChIP]	Public on Dec 31, 2017	26-Jun-2017	15-May-2019	29535300	R01CA204136
+geo	GSE100461	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [ATAC-seq]	Public on Dec 31, 2017	26-Jun-2017	25-Jul-2021	29535300	R01CA204136
+geo	GSE101644	Primary melanoma cell lines vary in glycolytic activity	Public on Mar 01, 2018	19-Jul-2017	25-Jul-2021	29628419	R01CA187076
+geo	GSE110052	Genome-wide analysis of Olig2-positive and Olig2-negative tumors in a glioma mouse model.	Public on Feb 02, 2019	2-Feb-2018	8-May-2019	29681511	R01CA208205
+geo	GSE111310	Widespread intronic polyadenylation diversifies immune cell transcriptomes	Public on May 04, 2018	1-Mar-2018	27-Mar-2019	29712909	P01CA155258
+geo	GSE98588	Genetically-defined Diffuse Large B-cell Lymphoma Subsets Arise by Distinct Pathogenetic Mechanisms and Predicts Outcome	Public on May 01, 2018	5-May-2017	25-Jul-2021	29713087	U24CA210999
+geo	GSE89568	Genome-wide gene-expression profile of mouse intestinal stem cells	Public on May 30, 2018	5-Nov-2016	15-May-2019	29727683	U54CA224068
+geo	GSE110905	Androgen Receptor-regulated genes in prostate cancer cells	Public on Feb 21, 2018	20-Feb-2018	27-Mar-2019	29808028	P50CA186786
+geo	GSE110903	RNA-seq profiling identifies Androgen Receptor-regulated genes in prostate cancer cells	Public on Feb 21, 2018	20-Feb-2018	27-Mar-2019	29808028	P50CA186786
+geo	GSE95000	MDA-PCa-2b cells, Control vs. ARlnc1 knockdown, AR-regulated gene signature generated by DHT treatment	Public on Feb 16, 2018	16-Feb-2017	13-Jun-2018	29808028	P50CA186786
+geo	GSE103871	TMPRSS2-ERG suppresses PTEN/TP53 alteration-induced cancer lineage plasticity	Public on May 16, 2018	14-Sep-2017	25-Jul-2021	29844131	U54CA224079
+geo	GSE104130	mTOR coordinates transcriptional programs and mitochondrial metabolism of activated Treg subsets to protect tissue homeostasis	Public on Sep 12, 2019	22-Sep-2017	25-Jul-2021	29844370	R01CA221290
+geo	GSE112494	Genome-wide chromatin accessibility profiles of TET2-disrupted T cells from a chronic lymphocytic leukemia (CLL) patient.	Public on Mar 30, 2018	29-Mar-2018	26-Mar-2019	29849141	P01CA214278
+geo	GSE100772	Transcription profiles of WT or MST1/2-KO total, CD8+ and CD8- DCs in vivo	Public on Jun 08, 2018	3-Jul-2017	25-Jul-2021	29849151	R01CA221290
+geo	GSE113670	RNA-seq of CD33 KO and control HSPCs	Public on Apr 26, 2018	25-Apr-2018	27-Mar-2019	29856956	P01CA214278
+geo	GSE115635	Systematic Identification of Epithelial–Stromal Crosstalk Signaling Networks in Ovarian Cancer	Public on Oct 22, 2018	11-Jun-2018	6-May-2021	29860390	P50CA098258
+geo	GSE112830	Neuroendocrine prostate cancer models	Public on Jun 22, 2018	6-Apr-2018	27-Mar-2019	29921838	U54CA224079
+geo	GSE112829	Methylation profile of neuroendocrine prostate cancer models	Public on Jun 22, 2018	6-Apr-2018	27-Mar-2019	29921838	U54CA224079
+geo	GSE112786	Molecular characterization of neuroendocrine prostate cancer organoids and PDOX by RNA-seq	Public on Jun 22, 2018	5-Apr-2018	27-Mar-2019	29921838	U54CA224079
+geo	GSE113126	Critical role for Lymphocytes in Producing FLT3LG in Tumors and Driving Checkpoint Therapy-Receptive Immune Microenvironments	Public on Apr 14, 2018	13-Apr-2018	21-Mar-2019	29942093	R01CA197363
+geo	GSE112982	Metabolic signaling directs the reciprocal lineage decisions of αβ and γδ T cells	Public on Jul 06, 2018	11-Apr-2018	19-Mar-2019	29980617	R01CA221290
+geo	GSE86495	Metabolic signaling directs the reciprocal lineage decisions of αβ and γδ T cells	Public on Jul 06, 2018	6-Sep-2016	5-Oct-2018	29980617	R01CA221290
+geo	GSE108138	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: A-to-I editing pools	Public on Jul 09, 2018	15-Dec-2017	8-Oct-2018	30010675	P50CA186786
+geo	GSE94586	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: a multiple protocol study across multiple laboratories	Public on Jul 09, 2018	6-Feb-2017	15-May-2019	30010675	P50CA186786
+geo	GSE94585	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: synthetic ratiometric pools	Public on Jul 09, 2018	6-Feb-2017	15-May-2019	30010675	P50CA186786
+geo	GSE94584	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: synthetic equimolar pool	Public on Jul 09, 2018	6-Feb-2017	15-May-2019	30010675	P50CA186786
+geo	GSE94582	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: human plasma pool	Public on Jul 09, 2018	6-Feb-2017	15-May-2019	30010675	P50CA186786
+geo	GSE114824	Pancreatic islets communicate with lymphoid tissues via exocytosis of insulin peptides	Public on Jul 18, 2018	23-May-2018	9-Nov-2020	30022165	P01AI118688
+geo	GSE114864	Tumor innate immunity primed by specific interferon-stimulated endogenous retroviruses (ATAC-seq)	Public on Oct 15, 2019	24-May-2018	15-Oct-2019	30038220	U01CA217885
+geo	GSE114601	Therapeutic efficacy of BET bromodomain protein inhhibitor and PD-1 blockade in genetically engineered mouse model of non-small cell lung cancer	Public on Aug 14, 2018	17-May-2018	25-Mar-2019	30087114	P01CA154303
+geo	GSE115821	Robust prediction of response to immune checkpoint blockade therapy in metastatic melanoma	Public on Aug 20, 2018	14-Jun-2018	27-Mar-2019	30127394	R33CA225291
+geo	GSE115821	Robust prediction of response to immune checkpoint blockade therapy in metastatic melanoma	Public on Aug 20, 2018	14-Jun-2018	27-Mar-2019	30127394	U54CA224070
+geo	GSE117131	Discovery of a Pro-Tumoral Clonogenic Unipotent Neutrophil Progenitor in Mouse and Human Bone Marrow	Public on Aug 28, 2018	16-Jul-2018	27-Mar-2019	30157427	U01CA224766
+geo	GSE117129	Identification of an Early Unipotent Neutrophil Progenitor with Pro-Tumoral Activity in Mouse and Human Bone Marrow	Public on Jul 17, 2018	16-Jul-2018	21-Mar-2019	30157427	U01CA224766
+geo	GSE103665	Copy number alteration burden is a pan-cancer prognostic factor associated with metastasis and death in conservatively treated prostate cancer: TAPG1 CNA cohort aCGH data	Public on Aug 18, 2018	8-Sep-2017	25-Jul-2021	30178746	U54CA224079
+geo	GSE113872	Transcriptional effects of small molecule targeting of ARID1A	Public on Jul 27, 2018	30-Apr-2018	21-Mar-2019	30197195	R01CA163915
+geo	GSE96781	A549 cells and MSR-A549 cells	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	U01CA217885
+geo	GSE96781	A549 cells and MSR-A549 cells	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	P01CA154303
+geo	GSE96780	Genome-wide maps of histone H3K27 acetylation in A549 and MSR-A549 cells.	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	U01CA217885
+geo	GSE96780	Genome-wide maps of histone H3K27 acetylation in A549 and MSR-A549 cells.	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	P01CA154303
+geo	GSE96779	mRNA expression profile of A549 cells and MSR-A549 cells with or without JQ1 treatment	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	U01CA217885
+geo	GSE96779	mRNA expression profile of A549 cells and MSR-A549 cells with or without JQ1 treatment	Public on Mar 28, 2019	17-Mar-2017	15-May-2019	30205046	P01CA154303
+geo	GSE89560	Inhibition of MEK and ATR induces synergistic killing of a Mll-Af4 B-ALL model harboring activated Ras mutation	Public on Nov 28, 2018	4-Nov-2016	15-May-2019	30266823	R01CA176745
+geo	GSE106384	Transcript analysis of CD45+Ter119+CD71+ erythroid-like progenitor cells from tumor-bearing mice	Public on Oct 29, 2018	31-Oct-2017	16-Apr-2021	30297899	R33CA225328
+geo	GSE117452	Differences in microRNA expression in breast cancer between women of African and European ancestry	Public on Dec 06, 2018	20-Jul-2018	27-Mar-2019	30321299	U24CA232979
+geo	GSE117615	Colonic adenoma and adjacent normal single-cell RNA-seq	Public on Oct 23, 2018	24-Jul-2018	25-Mar-2019	30346945	U2CCA233291
+geo	GSE114044	Colonic single-cell RNA-seq experiment	Public on Oct 23, 2018	4-May-2018	27-Feb-2020	30346945	U2CCA233291
+geo	GSE110239	Differential Gene expression in the mouse mammary tumors of PyMT-Malat1 wild-type (WT), PyMT-Malat1 knockout (KO) and PyMT-Malat1 knockout with Malat1 transgene expression (TG)	Public on Sep 18, 2018	6-Feb-2018	19-Mar-2019	30349115	U24CA209851
+geo	GSE115656	Alternative splicing analysis of pediatric B-cell acute lymphoblastic leukemia compared to normal bone marrow derived pro-B cells	Public on Oct 02, 2018	12-Jun-2018	3-Apr-2019	30357359	U01CA232563
+geo	GSE115655	Bone marrow derived human B cells [normal proB]	Public on Oct 02, 2018	12-Jun-2018	3-Apr-2019	30357359	U01CA232563
+geo	GSE115654	Aberrant splicing in B-cell acute lymphoblastic leukemia [cell line]	Public on Oct 02, 2018	12-Jun-2018	27-Mar-2019	30357359	U01CA232563
+geo	GSE115653	Aberrant splicing in B-cell acute lymphoblastic leukemia [B-ALL]	Public on Oct 02, 2018	12-Jun-2018	27-Mar-2019	30357359	U01CA232563
+geo	GSE120575	Defining T cell states associated with response to checkpoint immunotherapy in melanoma	Public on Oct 05, 2018	27-Sep-2018	26-Mar-2019	30388456	U54CA224068
+geo	GSE106510	T helper cells modulate intestinal stem cell renewal and differentiation	Public on Nov 01, 2018	3-Nov-2017	8-Apr-2019	30392957	U54CA224068
+geo	GSE113158	Elucidating the role of glycogen debranching enzyme AGL in bladder carcinogenesis by generation and characterization of knockout mice	Public on Mar 31, 2020	16-Apr-2018	28-Apr-2020	30403777	R01CA143971
+geo	GSE120711	Hippo kinases Mst1 and Mst2 sense and amplify IL-2R−STAT5 signaling in Treg cells to establish stable regulatory activity	Public on Nov 08, 2018	1-Oct-2018	13-Nov-2018	30413360	R01CA221290
+geo	GSE118872	Methylation profile of ewing sarcoma cell lines	Public on Oct 24, 2018	21-Aug-2018	23-Jan-2019	30420447	R01CA180279
+geo	GSE120134	Targeting the CALR Interactome in Myeloproliferative Neoplasms	Public on Sep 19, 2018	18-Sep-2018	21-Mar-2019	30429377	R01CA204396
+geo	GSE113229	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA204915
+geo	GSE113229	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA176745
+geo	GSE113228	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [ChIP-seq]	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA204915
+geo	GSE113228	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [ChIP-seq]	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA176745
+geo	GSE113227	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [RNA-seq]	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA204915
+geo	GSE113227	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [RNA-seq]	Public on Nov 01, 2018	16-Apr-2018	26-Mar-2019	30431433	R01CA176745
+geo	GSE115193	Evaluating pre-clinical models for studying NASH driven HCC.	Public on Dec 11, 2018	1-Jun-2018	27-Mar-2019	30449681	U01AA027681
+geo	GSE120073	Lung adenocarcinoma UNC0638 gene expression	Public on Sep 18, 2018	17-Sep-2018	25-Mar-2019	30455465	P01CA154303
+geo	GSE113563	Chromatin changes in G9a inhibited lung adenocarcinoma cells	Public on Dec 02, 2018	23-Apr-2018	25-Jul-2021	30455465	P01CA154303
+geo	GSE113402	H3K9 methyltransferases and demethylases control lung tumor-propagating cells and lung cancer progression (experiment 2)	Public on Apr 19, 2021	19-Apr-2018	20-Jul-2021	30455465	P01CA154303
+geo	GSE100455	H3K9 methyltransferases and demethylases control lung tumor-propagating cells and lung cancer progression	Public on Nov 30, 2018	26-Jun-2017	15-May-2019	30455465	P01CA154303
+geo	GSE120630	IKZF2 is required for myeloid leukemic stem cells by driving self-renewal and inhibiting the myeloid differentiation program	Public on Sep 29, 2018	28-Sep-2018	25-Mar-2019	30472158	R01CA176745
+geo	GSE120623	IKZF2 is required for myeloid leukemic stem cells by driving self-renewal and inhibiting the myeloid differentiation program II	Public on Sep 29, 2018	28-Sep-2018	25-Mar-2019	30472158	R01CA176745
+geo	GSE108367	IKZF2 is required for myeloid leukemic stem cells by driving self-renewal and inhibiting the myeloid differentiation program I	Public on Dec 21, 2017	20-Dec-2017	19-Mar-2019	30472158	R01CA176745
+geo	GSE111027	Single-cell RNA sequencing unveils a unique IL-10-producing T follicular helper subset that sustains humoral immunity during chronic viral infection	Public on Oct 29, 2018	22-Feb-2018	25-Mar-2019	30487586	R01CA203923
+geo	GSE111026	Single cell RNA-seq of IL-10-producing CD4 T cells during chronic LCMV infection	Public on Oct 29, 2018	22-Feb-2018	25-Mar-2019	30487586	R01CA203923
+geo	GSE111025	RNA-seq of Tfh IL21+ single producers and Tfh IL21+ IL10+ double producers	Public on Oct 29, 2018	22-Feb-2018	25-Mar-2019	30487586	R01CA203923
+geo	GSE111360	Organoid modeling of the tumor immune microenvironment	Public on Dec 13, 2018	2-Mar-2018	21-Mar-2019	30550791	U54CA224081
+geo	GSE112996	Transcript analysis of multi-locus sampled tumor tissue in patients with non-small cell lung cancer	Public on Nov 04, 2018	11-Apr-2018	20-Mar-2019	30560866	R33CA225328
+geo	GSE121599	Metabolic heterogeneity underlies reciprocal fates of TH17 cell stemness and plasticity	Public on Dec 27, 2018	22-Oct-2018	19-Mar-2019	30568299	R01CA221290
+geo	GSE121598	Metabolic heterogeneity underlies reciprocal fates of TH17 cell stemness and plasticity [scRNA-seq]	Public on Dec 27, 2018	22-Oct-2018	19-Mar-2019	30568299	R01CA221290
+geo	GSE121597	Metabolic heterogeneity underlies reciprocal fates of TH17 cell stemness and plasticity [ATAC-seq]	Public on Dec 27, 2018	22-Oct-2018	19-Mar-2019	30568299	R01CA221290
+geo	GSE107521	Transcription profiles of fate mapped IL17aiCre+flox/stop/flox-YFP+ TH17 cells, CD44intCD27+ TH17 cells and CD44hiCD27- TH17 cells from WT or Raptor-ko (flox/flox) mice after immunization with Myelin Oligodendrocyte Glycoprotein (MOG)	Public on Mar 20, 2019	30-Nov-2017	23-Mar-2019	30568299	R01CA221290
+geo	GSE122168	Identification of ADAR1 adenosine deaminase dependency in a subset of cancer cells	Public on Nov 06, 2018	5-Nov-2018	27-Mar-2019	30575730	P01CA154303
+geo	GSE80661	Non-overlapping control of transcriptome by Promoter and Super-Enhancer-Associated Dependencies	Public on Apr 26, 2017	26-Apr-2016	15-May-2019	30590042	P01CA155258
+geo	GSE116187	Homolog-selective degradation as a strategy to probe the function of CDK6 in AML	Public on Nov 20, 2018	23-Jun-2018	21-Mar-2019	30595531	P01CA154303
+geo	GSE121117	SHP2 Drives Adaptive Resistance to ERK Signaling Inhibition in Molecularly Defined Subsets of ERK-dependent Tumors	Public on Oct 12, 2018	11-Oct-2018	26-Mar-2019	30605687	R01CA204314
+geo	GSE118900	Molecular Signatures of Multiple Myeloma Progression through Single Cell RNA-Seq	Public on Nov 17, 2018	22-Aug-2018	27-Mar-2019	30607001	U54CA224018
+geo	GSE112865	Arg1 expression defines immunosuppressive subsets of immune infiltrating cells in cancer	Public on Dec 11, 2018	9-Apr-2018	6-Dec-2019	30613266	R01AI084880
+geo	GSE113217	Enhancer Domains in Gastrointestinal Stromal Tumor Regulate KIT Expression and are Targetable by BET Bromodomain Inhibition	Public on Jan 23, 2019	16-Apr-2018	24-Apr-2019	30630822	R01CA176745
+geo	GSE113215	Enhancer Domains in Gastrointestinal Stromal Tumor Regulate KIT Expression and are Targetable by BET Bromodomain Inhibition [RNA-seq]	Public on Jan 23, 2019	16-Apr-2018	24-Apr-2019	30630822	R01CA176745
+geo	GSE113207	Enhancer Domains in Gastrointestinal Stromal Tumor Regulate KIT Expression and are Targetable by BET Bromodomain Inhibition [ChIP-seq]	Public on Jan 23, 2019	16-Apr-2018	24-Apr-2019	30630822	R01CA176745
+geo	GSE96615	Neuronal brain region-specific DNA methylation and chromatin accessibility are associated with neuropsychiatric trait heritability	Public on Dec 17, 2018	14-Mar-2017	15-May-2019	30643296	U24CA180996
+geo	GSE96614	Neuronal brain region-specific DNA methylation and chromatin accessibility are associated with neuropsychiatric trait heritability [ATAC-Seq]	Public on Dec 17, 2018	14-Mar-2017	15-May-2019	30643296	U24CA180996
+geo	GSE96613	Neuronal brain region-specific DNA methylation and chromatin accessibility are associated with neuropsychiatric trait heritability [RNA-Seq]	Public on Dec 17, 2018	14-Mar-2017	15-May-2019	30643296	U24CA180996
+geo	GSE96612	Neuronal brain region-specific DNA methylation and chromatin accessibility are associated with neuropsychiatric trait heritability [Bisulfite-Seq]	Public on Dec 17, 2018	14-Mar-2017	15-May-2019	30643296	U24CA180996
+geo	GSE120720	GREB1 amplifies androgen receptor output in prostate cancer and contributes to antiandrogen resistance	Public on Feb 27, 2019	1-Oct-2018	27-Mar-2019	30644358	U54CA224079
+geo	GSE120680	GREB1 amplifies androgen receptor output in prostate cancer and contributes to antiandrogen resistance	Public on Feb 27, 2019	1-Oct-2018	27-Mar-2019	30644358	U54CA224079
+geo	GSE119153	Targeting the perivascular niche sensitizes disseminated tumour cells to chemotherapy	Public on Apr 23, 2019	28-Aug-2018	25-Apr-2019	30664790	U54CA224079
+geo	GSE121694	Clonal deletion of tumor-specific T cells by IFN-g confers therapeutic resistance to combination immune checkpoint blockade	Public on Oct 24, 2018	23-Oct-2018	19-Mar-2019	30737146	U01CA233100
+geo	GSE95433	Real-time quantitative RT-PCR analysis of mouse antigen specific T cells (CD8+Spas1)	Public on Feb 28, 2017	27-Feb-2017	12-Feb-2019	30737146	U01CA233100
+geo	GSE119139	Gene exression in single T cells across division states.	Public on Dec 01, 2018	28-Aug-2018	21-Mar-2019	30742126	U24CA224309
+geo	GSE99806	Genome-wide maps at the base-pair level, of chromatin regions enriched for H3 me3 marks in mouse glioma neurospheres (NS)	Public on Mar 18, 2019	8-Jun-2017	25-Jul-2021	30760578	U01CA224160
+geo	GSE94976	IDH1-R132H Low Grade Glioma animal brain tumors	Public on Mar 18, 2019	16-Feb-2017	15-May-2019	30760578	U01CA224160
+geo	GSE94975	Differential gene expression in IDH1-R132H Low Grade Glioma animal brain tumors brain in response to 10 Gy of radiation	Public on Mar 18, 2019	16-Feb-2017	15-May-2019	30760578	U01CA224160
+geo	GSE94974	Differential gene expression in IDH1-R132H Tumor Neurospheres generated from a mouse model of Low Grade Glioma	Public on Mar 18, 2019	16-Feb-2017	15-May-2019	30760578	U01CA224160
+geo	GSE94902	Differential gene expression in IDH1-R132H low grade glioma animal brain tumors brain in response to 20 Gy of radiation	Public on Feb 10, 2018	14-Feb-2017	15-May-2019	30760578	U01CA224160
+geo	GSE118859	SOX2 epidermal overexpression promotes cutaneous wound healing via activation of EGFR/MEK/ERK signaling mediated by EGFR ligands	Public on Sep 02, 2019	21-Aug-2018	3-Dec-2019	30772301	R33CA225291
+geo	GSE114519	Mitochondrial hypoxic stress induces RNA editing by APOBEC3G in lymphocytes	Public on Nov 22, 2018	16-May-2018	27-Mar-2019	30791937	U24CA232979
+geo	GSE114519	Mitochondrial hypoxic stress induces RNA editing by APOBEC3G in lymphocytes	Public on Nov 22, 2018	16-May-2018	27-Mar-2019	30791937	R01CA188900
+geo	GSE123728	Clinical and Immunologic Activity of a Single Dose of Neoadjuvant PD-1 Blockade and Predictors of Clinical Outcomes in Resectable Melanoma	Public on Feb 11, 2019	12-Dec-2018	31-Aug-2020	30804515	P01CA210944
+geo	GSE123739	Nr4a transcription factors limit CAR-T cell function in solid tumors	Public on Feb 13, 2019	12-Dec-2018	21-Mar-2019	30814732	U01DE028227
+geo	GSE123738	Nr4a transcription factors limit CAR-T cell function in solid tumors [RNA-Seq]	Public on Feb 13, 2019	12-Dec-2018	21-Mar-2019	30814732	U01DE028227
+geo	GSE123629	Nr4a transcription factors limit CAR-T cell function in solid tumors [ATAC-Seq]	Public on Feb 13, 2019	11-Dec-2018	21-Mar-2019	30814732	U01DE028227
+geo	GSE116256	Single-cell RNA-seq reveals AML hierarchies relevant to disease progression and immunity	Public on Feb 28, 2019	25-Jun-2018	26-Mar-2019	30827681	U2CCA233195
+geo	GSE120395	Regulatory T cell depletion promotes oncogenic Kras driven pancreatic tumorigenesis.	Public on Sep 24, 2019	24-Sep-2018	13-Jan-2020	30827862	U01CA224145
+geo	GSE120395	Regulatory T cell depletion promotes oncogenic Kras driven pancreatic tumorigenesis.	Public on Sep 24, 2019	24-Sep-2018	13-Jan-2020	31911451	U01CA224145
+geo	GSE128056	Combined inhibition of STAT3 and DNA repair in palbociclib-resistant ER-positive breast cancer	Public on Aug 31, 2019	8-Mar-2019	30-Nov-2019	30867218	R01AI109294
+geo	GSE112823	The gene expression profiles of antigen-primed wildtype and Ddit3-/- CD8 Pmel T cells	Public on Apr 02, 2019	6-Apr-2018	2-Apr-2019	30894532	U01CA232758
+geo	GSE122537	Transcriptomic analysis to functionally map the intrinsically disordered domain of EWS/FLI	Public on Feb 21, 2019	14-Nov-2018	28-Mar-2019	30899417	U54CA231641
+geo	GSE122536	Transcriptomic analysis to functionally map the intrinsically disordered domain of EWS/FLI [Experiment 2]	Public on Feb 21, 2019	14-Nov-2018	28-Mar-2019	30899417	U54CA231641
+geo	GSE122535	Transcriptomic analysis to functionally map the intrinsically disordered domain of EWS/FLI [Experiment 1]	Public on Feb 21, 2019	14-Nov-2018	28-Mar-2019	30899417	U54CA231641
+geo	GSE81476	PTEN-deficient synovial sarcoma	Public on Nov 03, 2016	16-May-2016	15-May-2019	30909651	U54CA231652
+geo	GSE128475	LKB1 orchestrates dendritic cell metabolic quiescence and anti-tumor immunity	Public on Apr 16, 2019	18-Mar-2019	19-Apr-2019	30911060	R01CA221290
+geo	GSE128474	LKB1 orchestrates dendritic cell metabolic quiescence and anti-tumor immunity [HT_MG-430_PM]	Public on Apr 16, 2019	18-Mar-2019	16-Jul-2019	30911060	R01CA221290
+geo	GSE128473	LKB1 orchestrates dendritic cell metabolic quiescence and anti-tumor immunity [MoGene-2_0-st]	Public on Apr 16, 2019	18-Mar-2019	16-Jul-2019	30911060	R01CA221290
+geo	GSE179282	Functional and Mechanistic Interrogation of BET Bromodomain Degraders for the Treatment of Metastatic Castration-resistant Prostate Cancer	Public on Jul 08, 2021	1-Jul-2021	9-Jul-2021	30918020	P50CA186786
+geo	GSE112037	Prostate Cancer Cell RNA-Seq (PC3E and GS689.Li)	Public on Jan 18, 2019	19-Mar-2018	19-Apr-2019	30923373	U01CA233074
+geo	GSE127465	Single cell transcriptomics of human and mouse lung cancers reveals conserved myeloid populations across individuals and species	Public on Apr 09, 2019	28-Feb-2019	3-Sep-2021	30979687	R01AI084880
+geo	GSE115536	Integrated transcriptomic and proteomic analysis of primary human umbilical vein endothelial cells	Public on Oct 28, 2019	8-Jun-2018	28-Oct-2019	30983154	U24CA210985
+geo	GSE122304	PolyA-sequencing in IMR-32 neuroblastoma cells with shRNA mediated depletion of CDK12, CDK13 or GFP.	Public on Mar 26, 2019	8-Nov-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE122303	PolyA-sequencing in Kelly and Kelly E9R neuroblastoma cells treated with THZ531 or DMSO	Public on Mar 26, 2019	8-Nov-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE113314	Gene expression profiling in neuroblastoma cell lines treated with THZ531 or DMSO	Public on Mar 26, 2019	18-Apr-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE113313	Nascent RNA sequencing in IMR-32 cells treated with THZ531 or DMSO	Public on Mar 26, 2019	18-Apr-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE113312	PolyA-sequencing in IMR-32 cells treated with THZ531 or DMSO	Public on Mar 26, 2019	18-Apr-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE113311	Global gene expression analysis in DMSO and THZ531 treated IMR32 and Kelly cells	Public on Mar 26, 2019	18-Apr-2018	19-Apr-2019	30988284	P01CA154303
+geo	GSE105095	Human CXCR5+CD45RA-CD8+ T cells subset in follicular lymphoma	Public on Sep 02, 2020	17-Oct-2017	2-Sep-2020	31028278	R01AI109294
+geo	GSE98827	Tumor microenvironment-activated angiotensin blockers enhance cancer immunotherapy	Public on Oct 01, 2019	11-May-2017	5-Jan-2020	31040208	R01CA208205
+geo	GSE128392	CD8+ T cells regulate tumor ferroptosis during cancer immunotherapy	Public on Mar 16, 2019	15-Mar-2019	26-May-2019	31043744	R01CA205426
+geo	GSE130414	The TP53 Apoptotic Network is a Primary Mediator of Resistance to BCL2 inhibition in AML Cells	Public on Apr 30, 2019	29-Apr-2019	8-Jan-2020	31048320	U54CA224019
+geo	GSE130413	Genome wide CRISPR screen for Venetoclax resisatnce in MOLM13 cells using Brunello library	Public on Apr 30, 2019	29-Apr-2019	8-Jan-2020	31048320	U54CA224019
+geo	GSE130412	Genome wide CRISPR screen for Venetoclax resisatnce in MOLM13 cells using Y. Kosuke library	Public on Apr 30, 2019	29-Apr-2019	8-Jan-2020	31048320	U54CA224019
+geo	GSE75233	Targeting Focal Adhesion Kinase Renders Pancreatic Cancers Responsive to Checkpoint Immunotherapy	Public on Nov 21, 2015	20-Nov-2015	27-Apr-2020	31076405	U54CA224083
+geo	GSE121560	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (RNA-seq of KLF6 KO)	Public on May 13, 2019	22-Oct-2018	13-Aug-2019	31085557	R01CA196658
+geo	GSE116254	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (RNA-Seq of LMNA KD)	Public on May 13, 2019	25-Jun-2018	13-Aug-2019	31085557	R01CA196658
+geo	GSE106422	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (H3 ChIPseq)	Public on May 13, 2019	2-Nov-2017	13-Aug-2019	31085557	R01CA196658
+geo	GSE104408	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia	Public on May 13, 2019	28-Sep-2017	25-Jul-2021	31085557	R01CA196658
+geo	GSE104406	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (RNA-Seq of HSCe)	Public on May 13, 2019	28-Sep-2017	25-Jul-2021	31085557	R01CA196658
+geo	GSE104405	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (ERRBS)	Public on May 13, 2019	28-Sep-2017	25-Jul-2021	31085557	R01CA196658
+geo	GSE104404	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia (ChIP-seq)	Public on May 13, 2019	28-Sep-2017	25-Jul-2021	31085557	R01CA196658
+geo	GSE104379	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia	Public on May 11, 2019	28-Sep-2017	16-Jul-2019	31085557	R01CA196658
+geo	GSE112027	HPV	Public on Mar 20, 2018	19-Mar-2018	29-May-2019	31097695	U01CA217885
+geo	GSE112026	A Novel Functional Splice Variant of AKT3 Defined by Analysis of Alternative Splice Expression in HPV-Positive Oropharyngeal Cancers (RNA-Seq)	Public on Mar 20, 2018	19-Mar-2018	29-May-2019	31097695	U01CA217885
+geo	GSE112023	A Novel Functional Splice Variant of AKT3 Defined by Analysis of Alternative Splice Expression in HPV-Positive Oropharyngeal Cancers (MBD-Seq)	Public on Mar 20, 2018	19-Mar-2018	29-May-2019	31097695	U01CA217885
+geo	GSE112021	Integrated Analysis of Whole-Genome ChIP-Seq and RNA-Seq Data of Primary Head and Neck Tumor Samples Associates HPV Integration Sites with Open Chromatin Marks (ChIP-Seq)	Public on Mar 20, 2018	19-Mar-2018	29-May-2019	31097695	U01CA217885
+geo	GSE118053	Expression data from WT, p110α-/-, p110δ-/-, and p110αδ double knockout HSC and LMPP hematopoietic populations	Public on Jun 06, 2019	2-Aug-2018	6-Jun-2019	31120863	R01CA229875
+geo	GSE130540	Distruption of TOX and TOX2 transcription factors in CAR T cells limits T cell exhaustion	Public on May 31, 2019	1-May-2019	30-Aug-2019	31152140	U01DE028227
+geo	GSE130539	Distruption of TOX and TOX2 transcription factors in CAR T cells limits T cell exhaustion [ATAC-Seq]	Public on May 31, 2019	1-May-2019	30-Aug-2019	31152140	U01DE028227
+geo	GSE130538	Distruption of TOX and TOX2 transcription factors in CAR T cells limits T cell exhaustion [RNA-Seq]	Public on May 31, 2019	1-May-2019	30-Aug-2019	31152140	U01DE028227
+geo	GSE130271	Profiling of protrusion-enriched RNAs from human breast cancer cell line MDA-MB-231	Public on Jun 01, 2019	24-Apr-2019	3-Sep-2019	31188523	R21CA191179
+geo	GSE129455	Cross-species single-cell analysis of pancreatic ductal adenocarcinoma reveals cancer-associated fibroblasts expressing MHC class II	Public on Jun 19, 2019	8-Apr-2019	8-Jun-2020	31197017	R33CA206949
+geo	GSE126974	TOX is a critical regulator of tumour-specific T cell differentiation	Public on Jun 24, 2019	23-Feb-2019	10-Jul-2019	31207604	R01AR070234
+geo	GSE126973	Transcriptome analysis of various TOX+ and TOX- tumor-infiltrating CD8 T cells and in vitro TOX over-expressing T cells.	Public on Jun 24, 2019	23-Feb-2019	10-Jul-2019	31207604	R01AR070234
+geo	GSE126970	ATACseq profiling of various TOX+ and TOX- tumor-infiltrating CD8 T cells	Public on Jun 24, 2019	23-Feb-2019	10-Jul-2019	31207604	R01AR070234
+geo	GSE126275	KSDM1b Role in Ewing Sarcoma	Public on Aug 29, 2019	8-Feb-2019	29-Aug-2019	31231465	U54CA231641
+geo	GSE128867	Genomic analyses of primary mouse prostate organoid culture with overexpression of FOXA1	Public on Jun 21, 2019	26-Mar-2019	1-Jul-2019	31243370	U54CA224079
+geo	GSE128667	Primary mouse prostate organoid culture with overexpression of FOXA1	Public on Jun 21, 2019	21-Mar-2019	1-Jul-2019	31243370	U54CA224079
+geo	GSE128666	Gene expression analysis of primary mouse prostate organoid culture with overexpression of FOXA1	Public on Jun 21, 2019	21-Mar-2019	1-Jul-2019	31243370	U54CA224079
+geo	GSE128421	Chromatin Landscape Analysis of primary mouse prostate organoid culture with overexpression of FOXA1	Public on Jun 21, 2019	18-Mar-2019	1-Jul-2019	31243370	U54CA224079
+geo	GSE123625	Distinct structural classes of activating FOXA1 alterations in prostate cancer progression	Public on Dec 12, 2018	11-Dec-2018	15-Jul-2019	31243372	P50CA186786
+geo	GSE123619	Distinct structural classes of activating FOXA1 alterations in prostate cancer progression [RNA-Seq]	Public on Dec 12, 2018	11-Dec-2018	15-Jul-2019	31243372	P50CA186786
+geo	GSE123618	Distinct structural classes of activating FOXA1 alterations in prostate cancer progression [ChIP-Seq]	Public on Dec 12, 2018	11-Dec-2018	15-Jul-2019	31243372	P50CA186786
+geo	GSE120585	Identifying and targeting angiogenesis-related microRNAs in ovarian cancer	Public on Feb 28, 2019	27-Sep-2018	22-Jun-2020	31289363	P50CA098258
+geo	GSE112414	Chromatin interaction of ERG and AR in established prostate cancer	Public on Mar 28, 2019	28-Mar-2018	20-May-2021	31296553	U54CA224079
+geo	GSE124127	Insulin induced alterations in chromatin acetylation and transcriptome in triple negative breast cancer cells	Public on Jul 30, 2019	19-Dec-2018	2-Aug-2019	31315653	R01CA192914
+geo	GSE126078	Molecular profiling stratifies diverse phenotypes of treatment-refractory metastatic castration-resistant prostate cancer	Public on Jul 17, 2019	4-Feb-2019	27-Jan-2021	31361600	R37CA230617
+geo	GSE116083	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	R37CA230617
+geo	GSE116083	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	U54CA224079
+geo	GSE116082	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [ribosome profiling]	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	R37CA230617
+geo	GSE116082	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [ribosome profiling]	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	U54CA224079
+geo	GSE116081	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [RNA-seq]	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	R37CA230617
+geo	GSE116081	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [RNA-seq]	Public on Jul 31, 2019	20-Jun-2018	3-Aug-2019	31366581	U54CA224079
+geo	GSE115676	EWS-FLI1 modulated alternative splicing of ARID1A reveals novel oncogenic function through the BAF complex	Public on Aug 30, 2019	12-Jun-2018	1-Sep-2019	31392992	R01CA204915
+geo	GSE133660	Gene expression data from IMR90 control, IMR90 shRRM2 and shRRM2/shp16	Public on Jul 02, 2019	1-Jul-2019	11-Sep-2019	31433975	U54CA224070
+geo	GSE123860	MUC1-C represses the RASSF1A tumor suppressor and activated Kras signaling in human carcinoma cells	Public on May 27, 2019	14-Dec-2018	26-Aug-2019	31435022	U01CA233084
+geo	GSE123860	MUC1-C represses the RASSF1A tumor suppressor and activated Kras signaling in human carcinoma cells	Public on May 27, 2019	14-Dec-2018	26-Aug-2019	31435022	U24CA232979
+geo	GSE134044	Ketone body signaling mediates intestinal stem cell homeostasis and adaptation to diet	Public on Oct 01, 2019	9-Jul-2019	2-Jan-2020	31442404	U54CA224068
+geo	GSE122230	Genome-wide gene-expression profile of mouse intestinal stem cells/progenitors/Paneth cells	Public on Jul 19, 2019	6-Nov-2018	17-Sep-2019	31442404	U54CA224068
+geo	GSE112205	scRNA-seq of Wild Type and Hmgcs2-/-epithelial cells	Public on Jul 19, 2019	22-Mar-2018	24-Dec-2020	31442404	U54CA224068
+geo	GSE122336	Single-cell profiling guided combinatorial immunotherapy for breast cancer resistance to Her2/neu and CDK4/6 targeted therapy	Public on Jun 19, 2019	8-Nov-2018	3-Sep-2019	31444334	U54CA209978
+geo	GSE123126	Mutationally-activated PI3’-kinase-a promotes de-differentiation of lung tumors initiated by the BRAFV600E oncoprotein kinase	Public on Mar 19, 2019	29-Nov-2018	4-Sep-2019	31452510	R01CA131261
+geo	GSE121217	Global gene expression analysis in PTEN versus GFP expressing H1650 lung adenocarcinoma cells	Public on Oct 16, 2018	15-Oct-2018	31-Aug-2021	31461649	U54CA224081
+geo	GSE17407	Microarray analysis to identify the molecular mechanisms whereby pDCs confer growth and drug resistance in MM cells	Public on Jul 31, 2009	29-Jul-2009	13-Apr-2020	31462737	P01CA155258
+geo	GSE126954	A lineage-resolved molecular atlas of C. elegans embryogenesis at single cell resolution	Public on Mar 01, 2019	22-Feb-2019	22-Feb-2020	31488706	U2CCA233285
+geo	GSE134026	Establishing hematopoietic stem cell gene therapy for breast cancer brain metastases using intratumoral myeloid cell-specific gene promoters	Public on Jan 21, 2020	9-Jul-2019	24-Jan-2020	31501884	R01CA121118
+geo	GSE111640	Deletion of Lats 1 and 2 in mouse pancreatic acinar cells	Public on Jul 26, 2019	9-Mar-2018	20-Sep-2019	31513574	U01CA224145
+geo	GSE136297	CytoScan HD array data from Human mammary epithelian cells after Cyclin E overexpression	Public on Aug 25, 2019	24-Aug-2019	24-Nov-2019	31513970	U01CA217885
+geo	GSE136078	Next genereration sequencing reveals that CNAs associated with cyclin E overexpression tranlate into changes in transcriptional output.	Public on Aug 30, 2020	20-Aug-2019	30-Aug-2020	31513970	U01CA217885
+geo	GSE134147	MUC1-C ACTIVATES THE NURD COMPLEX IN DEDIFFERENTIATION OF TRIPLE-NEGATIVE BREASTCANCER CELLS	Public on Mar 05, 2020	11-Jul-2019	13-Oct-2021	31519689	U01CA233084
+geo	GSE134147	MUC1-C ACTIVATES THE NURD COMPLEX IN DEDIFFERENTIATION OF TRIPLE-NEGATIVE BREASTCANCER CELLS	Public on Mar 05, 2020	11-Jul-2019	13-Oct-2021	31519689	U24CA232979
+geo	GSE135352	Napabucasin-mediated transcriptomic changes in human pancreatic cancer cell lines	Public on Sep 23, 2019	4-Aug-2019	23-Dec-2019	31527169	R33CA206949
+geo	GSE30588	Cytoplasmic MTDH associates with mRNAs	Public on Jul 13, 2011	12-Jul-2011	23-Sep-2019	31527591	P50CA174521
+geo	GSE129828	DNA Methylation Identifies Genetically and Prognostically Distinct Subtypes of Myelodysplastic Syndromes	Public on Sep 30, 2019	15-Apr-2019	15-Oct-2019	31582393	U01CA217885
+geo	GSE134598	Identification of PIKfyve kinase as a target in multiple myeloma	Public on Sep 19, 2019	22-Jul-2019	3-Feb-2020	31582538	U54CA224018
+geo	GSE136068	Retention of CD19 intron 2 contributes to CART-19 resistance in leukemias with subclonal frameshift mutations in CD19	Public on May 19, 2020	20-Aug-2019	19-May-2020	31591467	P01CA214278
+geo	GSE136068	Retention of CD19 intron 2 contributes to CART-19 resistance in leukemias with subclonal frameshift mutations in CD19	Public on May 19, 2020	20-Aug-2019	19-May-2020	31591467	U01CA232563
+geo	GSE117314	 N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [CUT&amp;RUN]	Public on Aug 12, 2019	18-Jul-2018	21-Oct-2019	31601799	R37CA230617
+geo	GSE106124	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis 	Public on Aug 12, 2019	24-Oct-2017	21-Oct-2019	31601799	R37CA230617
+geo	GSE106122	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [MeRIP-seq]	Public on Aug 12, 2019	24-Oct-2017	21-Oct-2019	31601799	R37CA230617
+geo	GSE105782	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis[Ribosome Profiling]	Public on Aug 12, 2019	23-Oct-2017	21-Oct-2019	31601799	R37CA230617
+geo	GSE105779	 N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [crispr]	Public on Aug 12, 2019	23-Oct-2017	21-Oct-2019	31601799	R37CA230617
+geo	GSE95372	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [RNA-Seq]	Public on Aug 12, 2019	24-Feb-2017	21-Oct-2019	31601799	R37CA230617
+geo	GSE135218	Lactate mediated epigenetic reprogramming during cancer associated fibroblast formation	Public on Dec 04, 2019	1-Aug-2019	4-Dec-2019	31663852	U24CA224020
+geo	GSE101082	Effect of CXCR4 knockdown in CAFs on gene expression	Public on Apr 03, 2019	10-Jul-2017	25-Jul-2021	31663852	U24CA224020
+geo	GSE128476	Papillomavirus-Colonized Murine Skin Confers Cancer Resistance	Public on Oct 25, 2019	18-Mar-2019	22-Nov-2019	31666702	U01CA233097
+geo	GSE135739	Amino acid licensing of regulatory T cell function requires signaling via small G proteins Rag and Rheb	Public on Nov 04, 2019	12-Aug-2019	6-Nov-2019	31668641	R01CA221290
+geo	GSE135301	Mevalonate metabolism-dependent protein geranylgeranylation regulates thymocyte egress	Public on Nov 04, 2019	2-Aug-2019	3-Feb-2020	31722972	R01CA221290
+geo	GSE138571	In vivo epigenetic CRISPR screen identifies Asf1a as an immunotherapeutic target in Kras-mutant lung adenocarcinoma	Public on Nov 26, 2019	8-Oct-2019	26-Nov-2019	31744829	U01CA233084
+geo	GSE133604	Single-cell transcriptomic profiling of mouse KrasG12DP53-/- (KP) lung tumors in response to tumor cell intrinsic Asf1a knockout (KO), anti-PD-1 or combination treatment (Asf1a KO + anti-PD-1).	Public on Nov 26, 2019	1-Jul-2019	26-Nov-2019	31744829	U01CA233084
+geo	GSE127232	In vitro and in vivo epigenome-wide CRISPR screens in mouse KrasG12D/P53-/- (KP) lung adenocarcinoma model	Public on Nov 26, 2019	26-Feb-2019	26-Jun-2020	31744829	U01CA233084
+geo	GSE127205	RNA-seq to compare gene expression profiles between Asf1a WT and Asf1a KO cells	Public on Nov 26, 2019	26-Feb-2019	26-Nov-2019	31744829	U01CA233084
+geo	GSE138490	FBXW7 is a defining driver of uterine carcinosarcoma by promoting epithelial-mesenchymal transition	Public on Nov 11, 2019	7-Oct-2019	31-Dec-2019	31772025	R01CA211339
+geo	GSE134175	Single cell ATAC sequencing profile of quiescent mesenchymal progenitors	Public on Dec 05, 2019	11-Jul-2019	19-Feb-2020	31809738	U54CA231652
+geo	GSE133995	RNA-seq profiling of adult skeletal muscle after long term conditional knockout of Hic1 [TA RNA-seq]	Public on Dec 05, 2019	8-Jul-2019	19-Feb-2020	31809738	U54CA231652
+geo	GSE110038	Hic1 defines quiescent mesenchymal progenitor subpopulations with distinct functions and fates in skeletal muscle regeneration	Public on Dec 05, 2019	1-Feb-2018	19-Feb-2020	31809738	U54CA231652
+geo	GSE110037	Single cell RNA sequencing time-course of mesenchymal progenitors during regeneration after notexin induced muscle injury	Public on Dec 05, 2019	1-Feb-2018	19-Feb-2020	31809738	U54CA231652
+geo	GSE110015	RNA sequencing time-course of mesenchymal progenitors during regeneration after notexin induced muscle injury	Public on Dec 05, 2019	1-Feb-2018	19-Feb-2020	31809738	U54CA231652
+geo	GSE110013	Transcript sequencing of mononuclear fractions from dissociated murine skeletal muscle	Public on Dec 05, 2019	1-Feb-2018	19-Feb-2020	31809738	U54CA231652
+geo	GSE110012	RNA-seq profiling of FACS purified MPs from adult skeletal muscle after conditional knockout of Hic1 [MP RNA-seq]	Public on Dec 05, 2019	1-Feb-2018	19-Feb-2020	31809738	U54CA231652
+geo	GSE137814	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [Cut&amp;Run]	Public on Nov 06, 2019	21-Sep-2019	11-Feb-2020	31821784	R01CA176745
+geo	GSE137813	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [RNA-Seq II]	Public on Nov 06, 2019	21-Sep-2019	11-Feb-2020	31821784	R01CA176745
+geo	GSE127508	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia	Public on Nov 06, 2019	28-Feb-2019	11-Feb-2020	31821784	R01CA176745
+geo	GSE127507	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [ChIP-seq]	Public on Nov 06, 2019	28-Feb-2019	11-Feb-2020	31821784	R01CA176745
+geo	GSE127506	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [RNA-seq]	Public on Nov 06, 2019	28-Feb-2019	11-Feb-2020	31821784	R01CA176745
+geo	GSE137016	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy [microarray]	Public on Dec 11, 2019	6-Sep-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE137015	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy [scRNA-seq]	Public on Dec 11, 2019	6-Sep-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE137014	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy [ATAC-seq]	Public on Dec 11, 2019	6-Sep-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE126072	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy.	Public on Dec 11, 2019	4-Feb-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE126071	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy. [RNA-Seq]	Public on Dec 11, 2019	4-Feb-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE126070	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy. [ATAC-Seq]	Public on Dec 11, 2019	4-Feb-2019	20-Dec-2019	31827283	R01CA221290
+geo	GSE131267	A large peptidome dataset improves HLA class I epitope prediction across most of the human population	Public on Dec 16, 2019	15-May-2019	16-Mar-2020	31844290	U24CA224331
+geo	GSE107637	RUVBL1/RUVBL2 ATPase Activity Drives PAQosome Maturation, DNA Replication and Radioresistance in Lung Cancer	Public on Dec 18, 2019	4-Dec-2017	18-Mar-2020	31883965	R01CA124633
+geo	GSE137636	Transcriptomic profiling of mouse lung tumor cells in response to CDK7 inhibitor treatment	Public on Dec 27, 2019	18-Sep-2019	8-Jan-2020	31883968	P01CA154303
+geo	GSE129299	Single-cell transcriptomic profiling of mouse lung tumor in response to CDK7 inhibitor, anti-PD-1 and combination treatment	Public on Dec 27, 2019	3-Apr-2019	8-Jan-2020	31883968	P01CA154303
+geo	GSE129298	Single-cell transcriptomic profiling of mouse lung tumor in response to CDK7 inhibitor, anti-PD-1 and combination treatment (Experiment 2)	Public on Dec 27, 2019	3-Apr-2019	8-Jan-2020	31883968	P01CA154303
+geo	GSE129297	Single-cell transcriptomic profiling of mouse lung tumor in response to CDK7 inhibitor, anti-PD-1 and combination treatment (Experiment 1)	Public on Dec 27, 2019	3-Apr-2019	8-Jan-2020	31883968	P01CA154303
+geo	GSE136579	Impact of BHLHE40-AS1 over expression in MCF10A cells	Public on Jun 10, 2020	28-Aug-2019	10-Jun-2020	31907974	R01CA207445
+geo	GSE66301	Gene expression profiling of patient's DCIS-IDC tandem lesions by RNA sequencing analysis	Public on Feb 26, 2015	25-Feb-2015	10-Jun-2020	31907974	R01CA207445
+geo	GSE140628	Regulatory T Cell depletion causes compensatory immune suppression and accelerated pancreatic carcinogenesis	Public on Jan 13, 2020	18-Nov-2019	11-Jan-2022	31911451	U01CA224145
+geo	GSE128707	Regulatory T cell depletion causes compensatory immune suppression and accelerated pancreatic carcinogenesis.	Public on Mar 23, 2019	22-Mar-2019	13-Jan-2020	31911451	U01CA224145
+geo	GSE141499	Homeostasis and transitional activation of regulatory T cells require c-Myc	Public on Jan 10, 2020	4-Dec-2019	14-May-2020	31911938	R01CA221290
+geo	GSE118272	STRIPAK directs PP2A activity to promote oncogenic transformation	Public on Dec 01, 2019	7-Aug-2018	3-Feb-2020	31913126	U01CA217885
+geo	GSE118272	STRIPAK directs PP2A activity to promote oncogenic transformation	Public on Dec 01, 2019	7-Aug-2018	3-Feb-2020	31913126	U01DE028227
+geo	GSE137833	Androgen Receptor Degraders Overcome Common Resistance Mechanisms Developed During Prostate Cancer Treatment	Public on Jan 12, 2020	23-Sep-2019	14-Jan-2020	31931431	P50CA186786
+geo	GSE135878	MYC and Twist1 Expression in Cancer Cells Activates Host Macrophages to Enable metastasis	Public on Jan 21, 2020	15-Aug-2019	21-Jan-2020	31933479	U01CA231776
+geo	GSE138693	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [scRNASeq]	Public on Jan 13, 2020	10-Oct-2019	13-Apr-2020	31935369	P01CA154303
+geo	GSE131687	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [ChIP + ATAC]	Public on Jan 13, 2020	23-May-2019	13-Apr-2020	31935369	P01CA154303
+geo	GSE131604	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway	Public on Jan 13, 2020	21-May-2019	21-Jan-2020	31935369	P01CA154303
+geo	GSE131601	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [YAP1 KO vs CTRL]	Public on Jan 13, 2020	21-May-2019	13-Apr-2020	31935369	P01CA154303
+geo	GSE131594	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [DMSO vs DORMANT]	Public on Jan 13, 2020	21-May-2019	13-Apr-2020	31935369	P01CA154303
+geo	GSE139248	DENDRO: genetic heterogeneity profiling and subclone detection by single-cell RNA sequencing	Public on Nov 10, 2019	22-Oct-2019	27-Jan-2020	31937348	P01CA210944
+geo	GSE139248	DENDRO: genetic heterogeneity profiling and subclone detection by single-cell RNA sequencing	Public on Nov 10, 2019	22-Oct-2019	27-Jan-2020	31937348	U2CCA233285
+geo	GSE139335	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	Public on Dec 02, 2019	24-Oct-2019	8-Feb-2022	31953400	U01CA233084
+geo	GSE139335	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	Public on Dec 02, 2019	24-Oct-2019	8-Feb-2022	31953400	U24CA232979
+geo	GSE139335	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	Public on Dec 02, 2019	24-Oct-2019	8-Feb-2022	34163028	U01CA233084
+geo	GSE139335	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	Public on Dec 02, 2019	24-Oct-2019	8-Feb-2022	34163028	U24CA232979
+geo	GSE153670	Bulk RNA sequencing from patient bone marrow samples	Public on Jul 02, 2020	1-Jul-2020	1-Oct-2020	32001516	P01CA214278
+geo	GSE130819	Genome-wide CRISPR/Cas9 guide library knockout screening in Nalm6 ALL cells under CART19 selective pressure	Public on Feb 17, 2020	7-May-2019	17-Feb-2020	32001516	P01CA214278
+geo	GSE130818	ATAC profiling of CART19 cells exposed to WT and BIDko Nalm6 cells	Public on Feb 17, 2020	7-May-2019	17-Feb-2020	32001516	P01CA214278
+geo	GSE130817	Transcriptional profiling of CART19 cells exposed to WT and BIDko Nalm6 cells	Public on Feb 17, 2020	7-May-2019	17-Feb-2020	32001516	P01CA214278
+geo	GSE130663	Impaired tumor death receptor signaling drives resistance to CAR T cell therapy	Public on Feb 17, 2020	3-May-2019	2-Jul-2020	32001516	P01CA214278
+geo	GSE129638	MLL-Menin inhibition reverses pre-leukemic progenitor self-renewal induced by NPM1c mutations	Public on Feb 11, 2020	11-Apr-2019	11-Feb-2020	32001657	R01CA176745
+geo	GSE129637	MLL-Menin inhibition reverses pre-leukemic progenitor self-renewal induced by NPM1c mutations [RNA-Seq]	Public on Feb 11, 2020	11-Apr-2019	11-Feb-2020	32001657	R01CA176745
+geo	GSE129636	MLL-Menin inhibition reverses pre-leukemic progenitor self-renewal induced by NPM1c mutations [ChIP-Seq]	Public on Feb 11, 2020	11-Apr-2019	11-Feb-2020	32001657	R01CA176745
+geo	GSE131918	ARID1A gene status shapes cancer immune phenotype and affects cancer immunotherapy	Public on May 06, 2020	29-May-2019	6-May-2020	32027624	P50CA186786
+geo	GSE131917	Intersection of ARID1A, EZH2 RNA-seq in OVCA429 cells with IFNγ treatment	Public on May 06, 2020	29-May-2019	6-May-2020	32027624	P50CA186786
+geo	GSE131916	RNA-seq in ARID1A WT, KO OVCA429 Cells after IFNγ treatment	Public on May 06, 2020	29-May-2019	6-May-2020	32027624	P50CA186786
+geo	GSE131915	ATAC-seq in ARID1A WT or KO OVCA429 Cells after interferron treatment	Public on May 06, 2020	29-May-2019	6-May-2020	32027624	P50CA186786
+geo	GSE123904	The single cell transcriptional landscape of lung adenocarcinoma metastasis	Public on Jan 14, 2020	16-Dec-2018	1-Apr-2020	32042191	U2CCA233284
+geo	GSE123903	The single cell transcriptional landscape of a mouse model of lung cancer metastasis	Public on Jan 14, 2020	16-Dec-2018	1-Apr-2020	32042191	U2CCA233284
+geo	GSE123902	The single cell transcriptional landscape of human lung adenocarcinoma (primary tumours and metastases)	Public on Jan 14, 2020	16-Dec-2018	1-Apr-2020	32042191	U2CCA233284
+geo	GSE137228	Blockade of lL17 signaling reverses alcohol-induced liver injury, and excessive alcohol drinking in mice.	Public on Apr 07, 2020	10-Sep-2019	7-Apr-2020	32051339	U01AA027681
+geo	GSE145007	Single residue in CD28-costimulated CAR-T cells limits long-term persistence and antitumor durability 	Public on Feb 11, 2020	10-Feb-2020	12-May-2020	32069268	P01CA214278
+geo	GSE141633	The landscape of alternative splicing in aggressive prostate cancers	Public on Dec 10, 2019	9-Dec-2019	4-Jun-2020	32086391	U01CA233074
+geo	GSE141633	The landscape of alternative splicing in aggressive prostate cancers	Public on Dec 10, 2019	9-Dec-2019	4-Jun-2020	32086391	U24CA232979
+geo	GSE143647	Joint Profiling of Chromatin Accessibility and CAR-T Integration Site Analysis at Population and Single-cell Levels	Public on Jan 15, 2020	14-Jan-2020	30-Mar-2020	32094195	P01CA214278
+geo	GSE143646	Joint Profiling of Chromatin Accessibility and CAR-T Integration Site Analysis at Population and Single-cell Levels II	Public on Jan 15, 2020	14-Jan-2020	30-Mar-2020	32094195	P01CA214278
+geo	GSE143645	Joint Profiling of Chromatin Accessibility and CAR-T Integration Site Analysis at Population and Single-cell Levels I	Public on Jan 15, 2020	14-Jan-2020	30-Mar-2020	32094195	P01CA214278
+geo	GSE142479	Neurofibromin is an Estrogen Receptor alpha Transcriptional Co-repressor in Breast cancer	Public on Feb 14, 2020	21-Dec-2019	20-May-2020	32142667	U54CA233223
+geo	GSE138727	TEAD1 and TEAD3 play redundant roles in human epidermal proliferation	Public on Oct 11, 2019	10-Oct-2019	9-Mar-2020	32142794	U01CA217885
+geo	GSE141142	An immune-centric exploration of BRCA1 and BRCA2 germline mutation related breast and ovarian cancers	Public on Nov 28, 2019	27-Nov-2019	23-Mar-2020	32164626	R01CA226776
+geo	GSE131690	H3K36 methyltransferase SETD2 regulates NHEJ during lymphoid and neural development	Public on Mar 23, 2020	23-May-2019	23-Mar-2020	32169821	R01CA176745
+geo	GSE131608	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [MIXCR]	Public on Mar 23, 2020	22-May-2019	23-Mar-2020	32169821	R01CA176745
+geo	GSE131588	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [RNA-seq]	Public on Mar 23, 2020	21-May-2019	23-Mar-2020	32169821	R01CA176745
+geo	GSE130904	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [seq]	Public on Mar 23, 2020	8-May-2019	23-Mar-2020	32169821	R01CA176745
+geo	GSE132486	JAK2 inhibition in Philadelphia chromosome like acute lymphoblastic leukemia	Public on May 28, 2020	10-Jun-2019	1-Jun-2020	32191635	U01CA232486
+geo	GSE137056	Differential modulation of the androgen receptor for prostate cancer therapy depends on the DNA response element	Public on Sep 07, 2019	6-Sep-2019	26-May-2020	32198885	P50CA186786
+geo	GSE138315	Epigenomic profiling of neuroblastoma cell lines	Public on Nov 03, 2019	2-Oct-2019	27-Apr-2020	32211329	U54CA232568
+geo	GSE138295	MYCN and MYC ChIP-Seq profiling in neuroblastoma cell lines	Public on Nov 03, 2019	2-Oct-2019	27-Apr-2020	32211329	U54CA232568
+geo	GSE133346	Functional comparison between healthy and multiple myeloma adipose stromal cells	Public on Jun 27, 2019	26-Jun-2019	30-Mar-2020	32215016	P01CA155258
+geo	GSE127957	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [shRNA screen]	Public on Mar 26, 2020	6-Mar-2019	25-Jun-2020	32220301	U54CA224079
+geo	GSE127241	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [ATAC-seq]	Public on Mar 26, 2020	26-Feb-2019	25-Jun-2020	32220301	U54CA224079
+geo	GSE126918	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer	Public on Mar 26, 2020	22-Feb-2019	25-Jun-2020	32220301	U54CA224079
+geo	GSE126917	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [RNA-seq]	Public on Mar 26, 2020	22-Feb-2019	25-Jun-2020	32220301	U54CA224079
+geo	GSE140490	Discovery of a selective inhibitor of Doublecortin Like Kinase 1	Public on Apr 06, 2020	15-Nov-2019	6-Jul-2020	32251410	U01CA224146
+geo	GSE145262	Gene expression in CD8+ T-cells from tumors in Wildtype mice and β2-adrenergic receptor knockout mice	Public on Feb 14, 2020	13-Feb-2020	27-Apr-2020	32286326	R01CA099326
+geo	GSE146826	High Throughput pMHC-I Tetramer Library Production Using Chaperone Mediated Peptide Exchange	Public on Mar 12, 2020	11-Mar-2020	27-Apr-2020	32312993	U54CA232568
+geo	GSE123917	Construction of brest cancer cell line BT20-specific interactome	Public on Mar 28, 2020	17-Dec-2018	27-Jun-2020	32321829	U54CA224076
+geo	GSE120919	Genome-wide survey of adjacent gene rearrangements in breast cancer identifies triple-negative specific BCL2L14-ETV6 fusions	Public on Mar 28, 2020	8-Oct-2018	25-Aug-2020	32321829	U54CA224076
+geo	GSE150176	scRNAseq of CD45+ cells within PDAC tumors treateted with CD40/ICB	Public on May 10, 2020	9-May-2020	10-Aug-2020	32324594	P01CA210944
+geo	GSE148732	Differential gene expression in mACVR1 NS v wt-ACVR1 NS.	Public on Apr 16, 2020	15-Apr-2020	31-Jul-2020	32332014	U01CA224160
+geo	GSE132044	Systematic comparative analysis of single cell RNA-sequencing methods	Public on Jun 01, 2019	31-May-2019	29-Aug-2020	32341560	U2CCA233195
+geo	GSE139962	Impact of splicing factors (ESRP1 and KHDRBS3) on prostate cancer biology	Public on Mar 04, 2020	5-Nov-2019	12-May-2020	32350277	U24CA232979
+geo	GSE128515	Therapeutic targeting of splicing in aggressive prostate cancer	Public on Mar 04, 2020	19-Mar-2019	12-May-2020	32350277	U24CA232979
+geo	GSE114052	AR regulated transcriptome in prostate cancer cells	Public on Mar 04, 2020	4-May-2018	12-May-2020	32350277	U24CA232979
+geo	GSE143790	Gene expression in DCIS.COM with BCL9 knockdown	Public on Jan 17, 2020	16-Jan-2020	7-May-2020	32352029	R01CA207445
+geo	GSE143313	BCL9/STAT3 Regulation of Transcriptional Enhancer Networks Promote DCIS Progression	Public on Jan 09, 2020	8-Jan-2020	7-May-2020	32352029	R01CA207445
+geo	GSE146811	Differentiated prostate luminal cells acquire enhanced regenerative potential after androgen ablation	Public on May 01, 2020	11-Mar-2020	22-May-2020	32355025	U54CA224079
+geo	GSE142481	Combined targeting of the BRD4-NUT-p300 axis in NUT midline carcinoma by dual selective bromodomain inhibitor, NEO2734	Public on Jun 19, 2020	21-Dec-2019	19-Jun-2020	32371576	R01CA124633
+geo	GSE139340	Somatic tissue engineering in mouse models reveals an actionable role for WNT pathway alterations in prostate cancer metastasis	Public on Apr 28, 2020	24-Oct-2019	7-Jul-2020	32376773	U54CA224079
+geo	GSE111907	Clinically-relevant cell type cross-talk identified from a lung tumor microenvironment interactome	Public on Jun 01, 2018	15-Mar-2018	18-May-2020	32381040	U24CA224309
+geo	GSE148715	“Direct to Drug” screening as a precision medicine tool in multiple myeloma	Public on May 22, 2020	15-Apr-2020	22-May-2020	32393731	U54CA224018
+geo	GSE149879	Landscape of four exhausted CD8 T cell subsets	Public on May 11, 2020	5-May-2020	10-Aug-2020	32396847	P01CA210944
+geo	GSE149877	Epigenetic landscape of four exhausted CD8 T cell subsets	Public on May 11, 2020	5-May-2020	10-Aug-2020	32396847	P01CA210944
+geo	GSE149876	Transcriptional landscape of four exhausted CD8 T cell subsets	Public on May 11, 2020	5-May-2020	10-Aug-2020	32396847	P01CA210944
+geo	GSE132062	Alternative splicing of LSD1+8a is mediated by SRRM4 in Neuroendocrine Prostate Cancer	Public on May 19, 2020	1-Jun-2019	19-May-2020	32403054	P50CA186786
+geo	GSE140819	A single-cell and single-nucleus RNA-Seq toolbox for fresh and frozen human tumors	Public on May 11, 2020	21-Nov-2019	26-Aug-2020	32405060	U2CCA233195
+geo	GSE126389	Type 1 dendritic cells are dysregulated systemically early in preinvasive carcinogenesis.	Public on Apr 15, 2020	11-Feb-2019	15-Jul-2020	32453421	P01CA210944
+geo	GSE126361	Peri-pancreatic LN cDC1 KPC	Public on Apr 15, 2020	11-Feb-2019	15-Jul-2020	32453421	P01CA210944
+geo	GSE126357	Inguinal LN cDC1 SubQ KPC	Public on Apr 15, 2020	11-Feb-2019	15-Jul-2020	32453421	P01CA210944
+geo	GSE126356	Inguinal LN CD11c SubQ KPC	Public on Apr 15, 2020	11-Feb-2019	15-Jul-2020	32453421	P01CA210944
+geo	GSE138388	Combined Inhibition of JAK/STAT Pathway and Lysine Demethylase 1 as a Novel Therapeutic Strategy in CSF3R/CEBPA Mutant Acute Myeloid Leukemia	Public on Jul 02, 2020	3-Oct-2019	2-Jul-2020	32471953	U54CA224019
+geo	GSE138387	Combined Inhibition of JAK/STAT Pathway and Lysine Demethylase 1 as a Novel Therapeutic Strategy in CSF3R/CEBPA Mutant Acute Myeloid Leukemia [LSD1i ChIP-seq]	Public on Jul 02, 2020	3-Oct-2019	2-Jul-2020	32471953	U54CA224019
+geo	GSE138386	Combined Inhibition of JAK/STAT Pathway and Lysine Demethylase 1 as a Novel Therapeutic Strategy in CSF3R/CEBPA Mutant Acute Myeloid Leukemia [RUX_GSK RNA-seq]	Public on Jul 02, 2020	3-Oct-2019	2-Jul-2020	32471953	U54CA224019
+geo	GSE138384	Combined Inhibition of JAK/STAT Pathway and Lysine Demethylase 1 as a Novel Therapeutic Strategy in CSF3R/CEBPA Mutant Acute Myeloid Leukemia [LSD1i RNA-seq]	Public on Jul 02, 2020	3-Oct-2019	2-Jul-2020	32471953	U54CA224019
+geo	GSE122166	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers	Public on Dec 02, 2019	5-Nov-2018	2-Jul-2020	32471953	U54CA224019
+geo	GSE122164	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (RNA-seq - simultaneous)	Public on Dec 02, 2019	5-Nov-2018	2-Jul-2020	32471953	U54CA224019
+geo	GSE122163	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (RNA-seq - orders)	Public on Dec 02, 2019	5-Nov-2018	2-Jul-2020	32471953	U54CA224019
+geo	GSE122162	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (ChIP-seq)	Public on Dec 02, 2019	5-Nov-2018	2-Jul-2020	32471953	U54CA224019
+geo	GSE122161	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (Microarray)	Public on Dec 02, 2019	5-Nov-2018	2-Jul-2020	32471953	U54CA224019
+geo	GSE132913	The major pre- and post-menopausal estrogens play opposing roles in obesity driven mammary inflammation and breast cancer development	Public on Jun 21, 2020	18-Jun-2019	21-Jun-2020	32492394	R01CA210440
+geo	GSE146204	TP53 abnormalities correlate with immune infiltration and are associated with response to flotetuzumab, an investigational immunotherapy, in acute myeloid leukemia	Public on Sep 21, 2020	2-Mar-2020	20-Jan-2022	32493790	U01CA232486
+geo	GSE134589	IMMUNE LANDSCAPES PREDICT CHEMOTHERAPY RESISTANCE AND IMMUNOTHERAPY RESPONSE IN ACUTE MYELOID LEUKAEMIA	Public on Jun 03, 2020	20-Jul-2019	2-Sep-2020	32493790	U01CA232486
+geo	GSE149652	Intratumoral CD4+ T cells mediate anti-tumor cytotoxicity in human bladder cancer	Public on Jun 01, 2020	30-Apr-2020	21-Apr-2021	32497499	U01CA233100
+geo	GSE149652	Intratumoral CD4+ T cells mediate anti-tumor cytotoxicity in human bladder cancer	Public on Jun 01, 2020	30-Apr-2020	21-Apr-2021	32497499	U01CA244452
+geo	GSE149652	Intratumoral CD4+ T cells mediate anti-tumor cytotoxicity in human bladder cancer	Public on Jun 01, 2020	30-Apr-2020	21-Apr-2021	32497499	R01CA194511
+geo	GSE147781	Comparison of mRNA profiles of AGO2 sufficent and deficient pancreatic tissue in the LSL KRASG12D mouse model of pancreatic cancer	Public on Mar 31, 2020	30-Mar-2020	22-Jun-2020	32499547	U01CA224145
+geo	GSE140440	Single Cell Analysis Reveals NUPR1 Promotes Docetaxel Resistance in Prostate Cancer	Public on Sep 01, 2020	15-Nov-2019	1-Sep-2020	32513898	P50CA186786
+geo	GSE126660	Epidermal basal cell-specific in vivo ribosome profiling to describe the translation landscape of HrasG12V and Eif2b5	Public on Jun 10, 2020	16-Feb-2019	10-Jun-2020	32516567	R37CA230617
+geo	GSE128980	Inter-myeloid cell synaptic antigen dispersal drives diversified anti-tumor T cell priming	Public on Nov 27, 2020	28-Mar-2019	27-Nov-2020	32516589	R01CA197363
+geo	GSE150155	Quantitative Analysis of Wild Type and CISH-/- induced pluripotent stem cell derived NK cells (iPSC-NK) Transcriptomes	Public on May 09, 2020	8-May-2020	10-Aug-2020	32531207	U01CA217885
+geo	GSE143944	Transcriptional profiling of ribociclib-treated sensitive and ribociclib resistant CAMA-1 cells	Public on Jun 22, 2020	20-Jan-2020	22-Jun-2021	32565737	U54CA209978
+geo	GSE130157	Signaling state and abundance of circulating immune cell subpopulations determine cancer response to immunotherapy	Public on Jun 09, 2020	22-Apr-2019	22-Jun-2021	32571915	U54CA209978
+geo	GSE148442	Transcriptomic analysis of IRAK4 in murine pancreatic cancer cells (KP2)	Public on Sep 02, 2020	10-Apr-2020	2-Sep-2020	32573499	U54CA224083
+geo	GSE149185	Novel Inhibitors of the Histone-Methyltransferase DOT1L Show Potent Antileukemic Activity in Patient-derived Xenografts	Public on Jun 01, 2020	23-Apr-2020	31-Aug-2020	32575123	R01CA176745
+geo	GSE149184	Novel Inhibitors of the Histone-Methyltransferase DOT1L Show Potent Antileukemic Activity in Patient-derived Xenografts (RNA-seq dataset)	Public on Jun 01, 2020	23-Apr-2020	31-Aug-2020	32575123	R01CA176745
+geo	GSE149183	Novel Inhibitors of the Histone-Methyltransferase DOT1L Show Potent Antileukemic Activity in Patient-derived Xenografts (ChIP-seq dataset)	Public on Jun 01, 2020	23-Apr-2020	31-Aug-2020	32575123	R01CA176745
+geo	GSE144240	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma	Public on Jun 22, 2020	24-Jan-2020	8-Aug-2020	32579974	U2CCA233195
+geo	GSE144240	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma	Public on Jun 22, 2020	24-Jan-2020	8-Aug-2020	32579974	U2CCA233238
+geo	GSE144239	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [ST]	Public on Jun 22, 2020	24-Jan-2020	18-Nov-2020	32579974	U2CCA233195
+geo	GSE144239	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [ST]	Public on Jun 22, 2020	24-Jan-2020	18-Nov-2020	32579974	U2CCA233238
+geo	GSE144238	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [CRISPR screen]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233195
+geo	GSE144238	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [CRISPR screen]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233238
+geo	GSE144237	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [WES]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233195
+geo	GSE144237	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [WES]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233238
+geo	GSE144236	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [single-cell RNA-seq]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233195
+geo	GSE144236	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [single-cell RNA-seq]	Public on Jun 22, 2020	24-Jan-2020	21-Sep-2020	32579974	U2CCA233238
+geo	GSE147368	Functional characterization of the novel GWAS-identified GP2 coding variant	Public on May 14, 2020	23-Mar-2020	27-Jun-2020	32581250	U01CA164973
+geo	GSE146609	IL-18BP is a secreted immune checkpoint and barrier to effective IL-18 immunotherapy	Public on Jun 29, 2020	8-Mar-2020	1-Jul-2020	32581358	U01CA233096
+geo	GSE145641	Recapitulation of Prostate Tissue Cell Type-specific Transcriptomes by an in vivo Primary Prostate Tissue Xenograft Model	Public on May 30, 2020	20-Feb-2020	7-Jul-2020	32584883	U24CA232979
+geo	GSE149425	The PD-1 pathway regulates development and function of memory CD8+ T cells following respiratory viral infection	Public on Jun 30, 2020	27-Apr-2020	2-Jul-2020	32610128	P01CA210944
+geo	GSE145502	ZipSeq : Barcoding for Real-time Mapping of Single Cell Transcriptomes	Public on Jun 01, 2020	18-Feb-2020	31-Aug-2020	32632238	R01CA197363
+geo	GSE133555	RNA seq to compare gene expression profiles between Npm1 WT and Npm1 knockdown cells	Public on Jun 22, 2020	30-Jun-2019	21-Sep-2020	32646968	P01CA154303
+geo	GSE151494	Neuropilin-1(NRP1) is a T cell memory checkpoint limiting long-term anti-tumor immunity	Public on Jul 01, 2020	29-May-2020	30-Sep-2020	32661362	P01CA210944
+geo	GSE153439	The Tumor Microenvironment and Inflammation Influence toxicity in patients with Large B Cell Lymphoma Treated with Axicabtagene Ciloleucel	Public on Jul 27, 2020	28-Jun-2020	19-Jan-2021	32669372	U01CA247576
+geo	GSE153438	The Tumor Microenvironment and Inflammation Influence toxicity in patients with Large B Cell Lymphoma Treated with Axicabtagene Ciloleucel [Nanostring]	Public on Jul 27, 2020	28-Jun-2020	19-Jan-2021	32669372	U01CA247576
+geo	GSE153437	The Tumor Microenvironment and Inflammation Influence toxicity in patients with Large B Cell Lymphoma Treated with Axicabtagene Ciloleucel [RNA-Seq]	Public on Jul 27, 2020	28-Jun-2020	19-Jan-2021	32669372	U01CA247576
+geo	GSE152029	Longitudinal serum auto-antibody response during HER2-CAR T cell therapy in a child with rhabdomyosarcoma identified using Protein microarray	Public on Jun 09, 2020	8-Jun-2020	27-Jul-2020	32669548	U54CA232568
+geo	GSE144581	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis [Cut&amp;Run ChIP-seq]	Public on Aug 04, 2020	30-Jan-2020	12-Aug-2020	32675324	U54CA243125
+geo	GSE137040	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis	Public on Aug 04, 2020	6-Sep-2019	3-Nov-2020	32675324	U54CA243125
+geo	GSE137039	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis [mouse RNA-seq]	Public on Aug 04, 2020	6-Sep-2019	7-Aug-2020	32675324	U54CA243125
+geo	GSE137038	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis[RNASeq]	Public on Aug 04, 2020	6-Sep-2019	7-Aug-2020	32675324	U54CA243125
+geo	GSE150681	Cancer cells deploy lipocalin-2 to collect limiting iron in leptomeningeal metastasis	Public on Jul 16, 2020	15-May-2020	20-Jul-2020	32675368	U2CCA233284
+geo	GSE150660	Single-cell atlas of human leptomeningeal metastasis	Public on Jul 16, 2020	15-May-2020	20-Jul-2020	32675368	U2CCA233284
+geo	GSE144848	Leptomeningeal metastatic cells outcompete macrophages for iron through Lipocalin-2	Public on Jul 16, 2020	6-Feb-2020	20-Jul-2020	32675368	U2CCA233284
+geo	GSE147976	RNA-seq analysis in NRG1 and enzalutamide treated 22Pc-EP cell line	Public on Jun 01, 2020	2-Apr-2020	15-Sep-2020	32679108	U54CA224079
+geo	GSE133690	Delineating mechanisms of immune evasion in lung carcinoma in situ	Public on Sep 01, 2020	2-Jul-2019	24-Aug-2021	32690541	U2CCA233280
+geo	GSE108124	Deciphering the genomic, epigenomic and transcriptomic landscapes of pre-invasive lung cancer lesions to determine prognosis	Public on Jan 01, 2019	15-Dec-2017	24-Aug-2021	32690541	U2CCA233280
+geo	GSE108123	Deciphering the genomic, epigenomic and transcriptomic landscapes of pre-invasive lung cancer lesions to determine prognosis III	Public on Jan 01, 2019	15-Dec-2017	24-Aug-2021	32690541	U2CCA233280
+geo	GSE108082	Deciphering the genomic, epigenomic and transcriptomic landscapes of pre-invasive lung cancer lesions to determine prognosis II	Public on Jan 01, 2019	14-Dec-2017	24-Aug-2021	32690541	U2CCA233280
+geo	GSE94611	Deciphering the genomic, epigenomic and transcriptomic landscapes of pre-invasive lung cancer lesions to determine prognosis I	Public on Jan 01, 2019	7-Feb-2017	24-Aug-2021	32690541	U2CCA233280
+geo	GSE116948	M1hot tumour associated macrophages are positively associated with tissue-resident memory T cell responses and survival outcomes in human lung cancer	Public on Jul 29, 2020	11-Jul-2018	29-Jul-2020	32699181	U01CA224766
+geo	GSE116947	M1hot tumour associated macrophages are positively associated with tissue-resident memory T cell responses and survival outcomes in human lung cancer (single cells).	Public on Jul 29, 2020	11-Jul-2018	29-Jul-2020	32699181	U01CA224766
+geo	GSE116946	M1hot tumour associated macrophages are positively associated with tissue-resident memory T cell responses and survival outcomes in human lung cancer (bulk).	Public on Jul 29, 2020	11-Jul-2018	29-Jul-2020	32699181	U01CA224766
+geo	GSE151838	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma [ChIP-seq]	Public on Jun 05, 2020	4-Jun-2020	27-Jul-2020	32699215	U54CA224081
+geo	GSE149612	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma	Public on Apr 30, 2020	29-Apr-2020	27-Jul-2020	32699215	U54CA224081
+geo	GSE149609	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma (RNA-Seq)	Public on Apr 30, 2020	29-Apr-2020	27-Jul-2020	32699215	U54CA224081
+geo	GSE149608	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma (WGBS)	Public on Apr 30, 2020	29-Apr-2020	27-Jul-2020	32699215	U54CA224081
+geo	GSE151924	Differential expression of endogenous retroelements (long terminal repeats) in ADA2 depleted primary endothelial cells (HUVECs)	Public on Jun 20, 2020	5-Jun-2020	22-Sep-2020	32743071	U01DE028227
+geo	GSE150540	Tanscriptional profile of primary endothelial cells (HUVEC) in ADA2 depleted setting and effect of Dipyridamole (DPM) treatment	Public on Jun 01, 2020	14-May-2020	31-Aug-2020	32743071	U01DE028227
+geo	GSE139055	A bifunctional nucleosome binding protein mediates specialized mSWI/SNF complex targeting and activity	Public on Aug 04, 2020	17-Oct-2019	3-Nov-2020	32747783	U54CA231638
+geo	GSE139054	A bifunctional nucleosome binding protein mediates specialized mSWI/SNF complex targeting and activity (RNA-seq dataset)	Public on Aug 04, 2020	17-Oct-2019	3-Nov-2020	32747783	U54CA231638
+geo	GSE139053	A bifunctional nucleosome binding protein mediates specialized mSWI/SNF complex targeting and activity (ChIP-seq dataset)	Public on Aug 04, 2020	17-Oct-2019	3-Nov-2020	32747783	U54CA231638
+geo	GSE153263	Identification of a CD117+​ ​CD71+​ ​ early ​unipotent​ neutrophil progenitor population in human bone marrow	Public on Aug 04, 2020	25-Jun-2020	6-Dec-2020	32814027	U01CA224766
+geo	GSE144688	Chromatin profiling reveals the relationship between EWS/FLI, LSD1, and the enhancer landscape in Ewing sarcoma	Public on May 12, 2020	3-Feb-2020	30-Sep-2021	32842875	U54CA231641
+geo	GSE144685	Chromatin profiling of the relationship between EWS/FLI, LSD1, and K27ac in multiple Ewing sarcoma cell lines	Public on May 12, 2020	3-Feb-2020	7-Apr-2021	32842875	U54CA231641
+geo	GSE144651	Chromatin profiling of the relationship between EWS/FLI, LSD1, and H3K27 acetylation	Public on May 12, 2020	2-Feb-2020	30-Sep-2021	32842875	U54CA231641
+geo	GSE132709	Chromatin profiling of the relationship between EWS/FLI, LSD1, and the enhancer landscape - H3K4 methylation	Public on May 12, 2020	13-Jun-2019	7-Apr-2021	32842875	U54CA231641
+geo	GSE153710	Genome-scale CRISPR-Cas9 knockout screening for identification of genes which regulate CD38 expression in RPMI 8226 cells	Public on Jul 03, 2020	2-Jul-2020	2-Oct-2020	32844992	P01CA155258
+geo	GSE154123	Multivalent proteins rapidly and reversibly phase-separate upon osmotic cell volume change	Public on Sep 17, 2020	9-Jul-2020	17-Dec-2020	32857953	P50CA186786
+geo	GSE152312	Effect of bone marrow microenvironment on the sensitivity of breast cancer cells to antiestrogens	Public on Jan 31, 2021	11-Jun-2020	3-May-2021	32859606	U54CA224079
+geo	GSE152312	Effect of bone marrow microenvironment on the sensitivity of breast cancer cells to antiestrogens	Public on Jan 31, 2021	11-Jun-2020	3-May-2021	32859606	U54CA233223
+geo	GSE141851	Massively parallel and time-resolved RNA sequencing in single cells with scNT-Seq	Public on Jul 21, 2020	11-Dec-2019	26-Sep-2020	32868927	U2CCA233285
+geo	GSE149165	The Gustatory Sensory G-Protein GNAT3 Suppresses Pancreatic Cancer Progression in Mice	Public on Apr 21, 2021	22-Apr-2020	22-Jul-2021	32882403	U01CA224145
+geo	GSE155605	A Non-genetic Mechanism Involving the Integrin b4/Paxillin Axis Contributes to Chemoresistance in Lung Cancer	Public on Aug 04, 2020	3-Aug-2020	6-Oct-2020	32947124	U54CA209978
+geo	GSE111922	Multiple myeloma tumors from Vk*MYC mice	Public on Feb 20, 2020	15-Mar-2018	28-Sep-2020	32954360	U54CA224018
+geo	GSE111921	Gene expression profile in multiple myeloma tumors from Vk*MYC mice	Public on Feb 20, 2020	15-Mar-2018	28-Sep-2020	32954360	U54CA224018
+geo	GSE110954	Evaluation of CNAs in multiple myeloma tumors from Vk*MYC mice	Public on Feb 20, 2020	21-Feb-2018	28-Sep-2020	32954360	U54CA224018
+geo	GSE151343	Functional precision medicine identifies new therapeutic candidates for medulloblastoma (expression dataset)	Public on Oct 01, 2020	28-May-2020	26-Dec-2020	33046443	U01CA217885
+geo	GSE154879	Overcoming primary and acquired resistance to anti-PD-L1 therapy by induction and activation of tumor-residing cDC1s	Public on Sep 24, 2020	22-Jul-2020	16-Nov-2020	33110069	U24CA232979
+geo	GSE155618	Role of PTEN in B-ALL	Public on Oct 13, 2020	3-Aug-2020	15-Feb-2022	33149299	U01CA232563
+geo	GSE155305	An Ifitm3-dependent amplification loop enables antibody responses and oncogenic signaling in B-cells	Public on Oct 13, 2020	28-Jul-2020	15-Feb-2022	33149299	U01CA232563
+geo	GSE158789	Functional Genomics Identifies Metabolic Vulnerabilities in Pancreatic Cancer [CRISPR Screen]	Public on Oct 01, 2020	30-Sep-2020	4-Jan-2021	33152323	U01CA224146
+geo	GSE158787	Functional Genomics Identifies Metabolic Vulnerabilities in Pancreatic Cancer	Public on Oct 01, 2020	30-Sep-2020	4-Jan-2021	33152323	U01CA224146
+geo	GSE158657	Functional Genomics Identifies Metabolic Vulnerabilities in Pancreatic Cancer [RNA-Seq]	Public on Oct 01, 2020	28-Sep-2020	4-Jan-2021	33152323	U01CA224146
+geo	GSE156889	ChIP-seq profiling of pancreatic tumor cells	Public on Aug 27, 2020	26-Aug-2020	26-Nov-2020	33158848	U54CA232568
+geo	GSE146835	Transcriptional profiling of mouse pancreatic tumor cells	Public on Sep 10, 2020	11-Mar-2020	26-Nov-2020	33158848	U54CA232568
+geo	GSE146834	Transcriptional profiling of mouse pancreatic tumor cells III	Public on Sep 10, 2020	11-Mar-2020	26-Nov-2020	33158848	U54CA232568
+geo	GSE146833	Transcriptional profiling of mouse pancreatic tumor cells II	Public on Sep 10, 2020	11-Mar-2020	26-Nov-2020	33158848	U54CA232568
+geo	GSE146832	Transcriptional profiling of mouse pancreatic tumor cells I	Public on Sep 10, 2020	11-Mar-2020	26-Nov-2020	33158848	U54CA232568
+geo	GSE142082	Genome-wide maps of macroH2A and H2B distribution in murine embryonic fibroblasts in dependence of Lsh.	Public on Aug 13, 2020	16-Dec-2019	12-Nov-2020	33159050	R01CA163915
+geo	GSE150806	Quantitative Analysis of different NK cell types Transcriptomes	Public on Oct 12, 2020	18-May-2020	16-Nov-2020	33178188	U01CA217885
+geo	GSE150363	Quantitative Analysis of different NK cell types Transcriptomes	Public on May 13, 2020	12-May-2020	16-Nov-2020	33178188	U01CA217885
+geo	GSE141121	PD-1 and TIGIT co-expression identifies a circulating CD8 T cell population predictive of response to anti-PD-1 therapy in melanoma and Merkel-cell carcinoma patients	Public on Nov 27, 2020	27-Nov-2019	27-Nov-2020	33188038	UM1CA154967
+geo	GSE141120	PD-1 and TIGIT co-expression identifies a circulating CD8 T cell population predictive of response to anti-PD-1 therapy in melanoma and Merkel-cell carcinoma patients [TCR-seq]	Public on Nov 27, 2020	27-Nov-2019	27-Nov-2020	33188038	UM1CA154967
+geo	GSE141119	PD-1 and TIGIT co-expression identifies a circulating CD8 T cell population predictive of response to anti-PD-1 therapy in melanoma and Merkel-cell carcinoma patients [RNA-seq]	Public on Nov 27, 2020	27-Nov-2019	27-Nov-2020	33188038	UM1CA154967
+geo	GSE158921	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Pggt1b_ATACseq]	Public on Jan 20, 2021	2-Oct-2020	20-Jan-2021	33207246	R01CA221290
+geo	GSE158920	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Fntb_ATACseq]	Public on Jan 20, 2021	2-Oct-2020	20-Jan-2021	33207246	R01CA221290
+geo	GSE158863	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells	Public on Jan 20, 2021	1-Oct-2020	24-Jan-2021	33207246	R01CA221290
+geo	GSE158862	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Microarray Dataset 3]	Public on Jan 20, 2021	1-Oct-2020	24-Jan-2021	33207246	R01CA221290
+geo	GSE158861	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Microarray Dataset 2]	Public on Jan 20, 2021	1-Oct-2020	24-Jan-2021	33207246	R01CA221290
+geo	GSE158860	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Microarray Dataset 1]	Public on Jan 20, 2021	1-Oct-2020	24-Jan-2021	33207246	R01CA221290
+geo	GSE147326	Single Cell RNA-Seq data for Cancer Stem Like Reversal Project	Public on Dec 07, 2020	21-Mar-2020	22-Jun-2021	33221681	U54CA209978
+geo	GSE104574	Transcriptional Signaling Centers Regulate Erythroid Gene Expression and are Disrupted in Common Variations of Human Red Blood Cell Traits	Public on Sep 14, 2020	3-Oct-2017	25-Jul-2021	33230299	P01CA155258
+geo	GSE74483	BMP signaling cooperates with GATA factors to govern stage-specific gene expression during erythroid differentiation	Public on Sep 14, 2020	29-Oct-2015	16-Feb-2021	33230299	P01CA155258
+geo	GSE74482	BMP signaling cooperates with GATA factors to govern stage-specific gene expression during erythroid differentiation [RNA-Seq]	Public on Sep 14, 2020	29-Oct-2015	16-Feb-2021	33230299	P01CA155258
+geo	GSE74479	BMP signaling cooperates with GATA factors to govern stage-specific gene expression during erythroid differentiation [ChIP-Seq]	Public on Sep 14, 2020	29-Oct-2015	16-Feb-2021	33230299	P01CA155258
+geo	GSE74472	BMP signaling cooperates with GATA factors to govern stage-specific gene expression during erythroid differentiation [ATAC-Seq]	Public on Sep 14, 2020	29-Oct-2015	16-Feb-2021	33230299	P01CA155258
+geo	GSE157290	Macrophage Gene Expression in PyMT Tumor Progression	Public on Sep 02, 2020	1-Sep-2020	2-Dec-2020	33257795	R01CA192914
+geo	GSE159913	Single Cell RNAseq on Renal adenocarcinoma	Public on Nov 16, 2020	23-Oct-2020	20-Nov-2021	33264598	R01CA197363
+geo	GSE153499	Protein synthesis inhibitors stimulate MondoA transcriptional activity by driving accumulation of glucose 6-phosphate	Public on Dec 07, 2020	29-Jun-2020	15-Dec-2020	33292639	U54CA224076
+geo	GSE148372	RNA-Seq of brain metastatic breast cancer cell lines after knockout of lipid metabolism genes using CRISPR/Cas9 gene editing	Public on Jun 26, 2020	9-Apr-2020	22-Sep-2021	33299191	R01CA208205
+geo	GSE148283	RNA-Seq of multiplexed metastasis xenogfrates of barcoded cell line pools	Public on Jun 26, 2020	8-Apr-2020	22-Sep-2021	33299191	R01CA208205
+geo	GSE159576	Targeting Transcriptional Regulation of SARS-CoV-2 Entry Factors ACE2 and TMPRSS2	Public on Nov 30, 2020	19-Oct-2020	1-Feb-2021	33310900	P50CA186786
+geo	GSE149720	17 Models: Buparlisib-treated Patient Derived Xenograft (PDX) Reversed Phase Protein Array (RPPA) Data	Public on Jan 27, 2021	1-May-2020	6-May-2021	33371187	U54CA224083
+geo	GSE148949	BKM120 Treated WHIMs_17 Model Cohort	Public on Dec 31, 2020	20-Apr-2020	2-Jan-2021	33371187	U54CA224083
+geo	GSE119716	Culturing human fusion-positive rhabdomyosarcoma cell lines as rhabdospheres enriches for stemness and Notch signaling	Public on Feb 22, 2021	10-Sep-2018	22-Feb-2021	33372065	U54CA231630
+geo	GSE138343	Genome wide CRISPR screen for Sorafenib resistance in MOLM13 and MV411 cells using Y. Kosuke library	Public on May 19, 2021	2-Oct-2019	19-May-2021	33375770	U54CA224019
+geo	GSE159927	Droplet based mRNA sequencing of fixed and permeabilized cells by CLInt-Seq allows for antigen specific TCR cloning	Public on Jan 01, 2021	23-Oct-2020	1-Feb-2021	33431692	U01CA233074
+geo	GSE158459	Targeted single-cell RNAseq of tonsil organoid cultures	Public on Sep 24, 2020	23-Sep-2020	30-Sep-2021	33432170	U54CA224081
+geo	GSE161353	Tumor-infiltrating mast cells are associated with resistance to anti-PD-1 therapy.	Public on Dec 07, 2020	12-Nov-2020	8-Mar-2021	33436641	U54CA224070
+geo	GSE161351	Tumor-infiltrating mast cells are associated with resistance to anti-PD-1 therapy. [RNA-Seq]	Public on Dec 07, 2020	12-Nov-2020	8-Mar-2021	33436641	U54CA224070
+geo	GSE160885	Tumor-infiltrating mast cells are associated with resistance to anti-PD-1 therapy. [TCR]	Public on Dec 07, 2020	5-Nov-2020	8-Mar-2021	33436641	U54CA224070
+geo	GSE144020	Genomic alterations during the in situ to invasive ductal breast carcinoma transition shaped by the immune system	Public on Dec 01, 2020	21-Jan-2020	2-Mar-2021	33443130	U24CA224331
+geo	GSE164179	A CRISPR/Cas9-engineered ARID1A-deficient human gastric cancer organoid model reveals essential and non-essential modes of oncogenic transformation	Public on Jan 05, 2021	4-Jan-2021	6-Apr-2021	33451982	U54CA224081
+geo	GSE164179	A CRISPR/Cas9-engineered ARID1A-deficient human gastric cancer organoid model reveals essential and non-essential modes of oncogenic transformation	Public on Jan 05, 2021	4-Jan-2021	6-Apr-2021	33451982	R01CA163915
+geo	GSE160758	Inhibitory signaling sustains a distinct early memory CD8+ T cell precursor that is resistant to DNA damage	Public on Nov 30, 2020	3-Nov-2020	1-Mar-2021	33452106	P01CA210944
+geo	GSE158450	Cell-type, single-cell, and spatial signatures of brain-region specific splicing in postnatal development	Public on Nov 17, 2020	23-Sep-2020	1-Feb-2021	33469025	U24CA180996
+geo	GSE142833	Global gene expression analysis of breast cancer cell line responses to Topsentinol L Trisulfate or DMSO as the vehicle control	Public on Jul 30, 2020	2-Jan-2020	2-Feb-2021	33477536	U54CA209978
+geo	GSE161363	Single-cell lineages reveal the rates, routes, and drivers of metastasis in cancer xenografts	Public on Dec 13, 2020	12-Nov-2020	6-Apr-2021	33479121	U54CA224081
+geo	GSE146867	RNA editing enzyme APOBEC3A promotes pro-inflammatory (M1) macrophage polarization	Public on Mar 13, 2020	12-Mar-2020	2-Feb-2021	33483601	U24CA232979
+geo	GSE146867	RNA editing enzyme APOBEC3A promotes pro-inflammatory (M1) macrophage polarization	Public on Mar 13, 2020	12-Mar-2020	2-Feb-2021	33483601	R01CA188900
+geo	GSE164141	MUC1-C integrates activation of the IFN-γ pathway with suppression of the tumor immune microenvironment in triple-negative breast cancer	Public on Feb 03, 2021	2-Jan-2021	3-Feb-2021	33495298	U01CA233084
+geo	GSE164141	MUC1-C integrates activation of the IFN-γ pathway with suppression of the tumor immune microenvironment in triple-negative breast cancer	Public on Feb 03, 2021	2-Jan-2021	3-Feb-2021	33495298	U24CA232979
+geo	GSE166940	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [ChIPseq]	Public on Feb 24, 2021	17-Feb-2021	24-Feb-2021	33527899	R01CA204396
+geo	GSE163470	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia	Public on Feb 24, 2021	18-Dec-2020	24-Feb-2021	33527899	R01CA204396
+geo	GSE163469	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [RNAseq_4cellLines]	Public on Feb 24, 2021	18-Dec-2020	24-Feb-2021	33527899	R01CA204396
+geo	GSE163466	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [RNAseq_MV411]	Public on Feb 24, 2021	18-Dec-2020	24-Feb-2021	33527899	R01CA204396
+geo	GSE157429	Single-cell B receptor VDJ sequencing from HGSOC isolated B cells	Public on Nov 24, 2020	3-Sep-2020	7-Apr-2021	33536615	R01CA211913
+geo	GSE157429	Single-cell B receptor VDJ sequencing from HGSOC isolated B cells	Public on Nov 24, 2020	3-Sep-2020	7-Apr-2021	33536615	U01CA232758
+geo	GSE146820	IgA transcytosis and tumor antigen recognition govern anti-tumor immunity in ovarian cancer	Public on Nov 24, 2020	11-Mar-2020	7-Apr-2021	33536615	R01CA211913
+geo	GSE146820	IgA transcytosis and tumor antigen recognition govern anti-tumor immunity in ovarian cancer	Public on Nov 24, 2020	11-Mar-2020	7-Apr-2021	33536615	U01CA232758
+geo	GSE146776	Transcriptional changes in in vitro treated OVCAR3 cells with non-specific IgG and IgA and Specific IgA antibodies	Public on Nov 24, 2020	11-Mar-2020	7-Apr-2021	33536615	R01CA211913
+geo	GSE146776	Transcriptional changes in in vitro treated OVCAR3 cells with non-specific IgG and IgA and Specific IgA antibodies	Public on Nov 24, 2020	11-Mar-2020	7-Apr-2021	33536615	U01CA232758
+geo	GSE149482	Genome-wide maps of histone modifications in mouse tumor-derived cell lines	Public on Nov 20, 2020	28-Apr-2020	19-Feb-2021	33536620	U54CA224065
+geo	GSE149272	Elevated NSD3 Histone Methylation Activity Drives Squamous Cell Lung Cancer	Public on Nov 24, 2020	24-Apr-2020	23-Feb-2021	33536620	U54CA224065
+geo	GSE153129	SPT6 Promotes Epidermal Differentiation and Blockade of an Intestinal Phenotype through Control of Transcriptional Elongation	Public on Dec 21, 2020	24-Jun-2020	8-Feb-2021	33542242	U01CA217885
+geo	GSE164551	Biallelic loss of BCMA as a resistance mechanism to CAR T cell therapy in a patient with Multiple Myeloma	Public on Jan 11, 2021	11-Jan-2021	22-Feb-2021	33558511	P01CA155258
+geo	GSE164248	Gain-of-Function p53 Protein Transferred via Small Extracellular Vesicles Promotes Conversion of Fibroblasts to a Cancer-Associated Phenotype [microarray]	Public on Jan 06, 2021	4-Jan-2021	17-Feb-2021	33567287	P50CA098258
+geo	GSE148698	Gain-of-Function p53 Protein Transferred via Small Extracellular Vesicles Promotes Conversion of Fibroblasts to a Cancer-Associated Phenotype	Public on Nov 18, 2020	15-Apr-2020	17-Feb-2021	33567287	P50CA098258
+geo	GSE161496	Differential expression genes analysis of knocking down Prmt1 and Ripk1 in MC38/gp100 cell line	Public on Feb 24, 2021	14-Nov-2020	24-Feb-2021	33589527	R01CA187076
+geo	GSE151611	p300/CBP mediated activation of MHCI machinery and IFNg receptor loci controls chemoimmunotherapy	Public on Feb 01, 2021	2-Jun-2020	16-Mar-2021	33602823	U01AA027681
+geo	GSE151611	p300/CBP mediated activation of MHCI machinery and IFNg receptor loci controls chemoimmunotherapy	Public on Feb 01, 2021	2-Jun-2020	16-Mar-2021	33602823	U24CA232979
+geo	GSE126288	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U01AA027681
+geo	GSE126288	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U24CA232979
+geo	GSE126287	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [AT_MC]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U01AA027681
+geo	GSE126287	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [AT_MC]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U24CA232979
+geo	GSE126274	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [CCO19-MC]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U01AA027681
+geo	GSE126274	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [CCO19-MC]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U24CA232979
+geo	GSE126273	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [TRAMP]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U01AA027681
+geo	GSE126273	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [TRAMP]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U24CA232979
+geo	GSE126269	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [Myc_CaP]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U01AA027681
+geo	GSE126269	Platinoid drugs augment immunotherapy via histone acetylation of MHCI machinery genes [Myc_CaP]	Public on Feb 01, 2021	8-Feb-2019	16-Mar-2021	33602823	U24CA232979
+geo	GSE164991	BAF subunit switching regulates chromatin accessibility to control cell cycle exit in the developing mammalian cortex	Public on Jan 18, 2021	17-Jan-2021	19-Apr-2021	33602870	R01CA163915
+geo	GSE164990	BAF subunit switching regulates chromatin accessibility to control cell cycle exit in the developing mammalian cortex [RNA-seq]	Public on Jan 18, 2021	17-Jan-2021	19-Apr-2021	33602870	R01CA163915
+geo	GSE164989	BAF subunit switching regulates chromatin accessibility to control cell cycle exit in the developing mammalian cortex [ATAC-seq]	Public on Jan 18, 2021	17-Jan-2021	19-Apr-2021	33602870	R01CA163915
+geo	GSE147305	Transcriptional profiling of control versus PAF depleted human lung cancer cell line (H1792)	Public on Apr 21, 2021	20-Mar-2020	21-Apr-2021	33626321	U54CA224065
+geo	GSE136571	Transcriptional profiling of control versus PAF depleted mouse lung cancer cell lines	Public on Apr 21, 2021	28-Aug-2019	21-Apr-2021	33626321	U54CA224065
+geo	GSE166159	Lipid signalling enforces functional specialization of Treg cells in tumours [scRNA-seq EAE]	Public on Feb 24, 2021	4-Feb-2021	1-Mar-2021	33627871	R01CA221290
+geo	GSE165259	Lipid signalling enforces functional specialization of Treg cells in tumours	Public on Feb 24, 2021	21-Jan-2021	1-Mar-2021	33627871	R01CA221290
+geo	GSE165258	Lipid signalling enforces functional specialization of Treg cells in tumours [scRNA-seq]	Public on Feb 24, 2021	21-Jan-2021	1-Mar-2021	33627871	R01CA221290
+geo	GSE165257	Lipid signalling enforces functional specialization of Treg cells in tumours [microarray #2]	Public on Feb 24, 2021	21-Jan-2021	1-Mar-2021	33627871	R01CA221290
+geo	GSE149573	Lipid signalling enforces functional specialization of Treg cells in tumours [microarray #1]	Public on Feb 24, 2021	29-Apr-2020	1-Mar-2021	33627871	R01CA221290
+geo	GSE155007	A bladder cancer patient-derived xenograft reflects aggressive growth dynamics in vivo and in organoids	Public on Feb 03, 2021	23-Jul-2020	10-Mar-2021	33633154	R37CA230617
+geo	GSE162690	ArchR: An integrative and scalable software package for single-cell chromatin accessibility analysis	Public on Dec 05, 2020	4-Dec-2020	6-Mar-2021	33633365	U2CCA233311
+geo	GSE160341	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions	Public on Feb 25, 2021	28-Oct-2020	28-Feb-2021	33636132	R01CA221290
+geo	GSE160313	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [Pofut1 ATAC-seq]	Public on Feb 25, 2021	28-Oct-2020	1-Mar-2021	33636132	R01CA221290
+geo	GSE160305	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [scRNA-seq]	Public on Feb 25, 2021	28-Oct-2020	1-Mar-2021	33636132	R01CA221290
+geo	GSE160225	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [Pofut1_microarray]	Public on Feb 25, 2021	27-Oct-2020	1-Mar-2021	33636132	R01CA221290
+geo	GSE160218	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [NICD_microarray]	Public on Feb 25, 2021	27-Oct-2020	1-Mar-2021	33636132	R01CA221290
+geo	GSE148681	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [microarray_dataset1]	Public on Feb 25, 2021	14-Apr-2020	28-Feb-2021	33636132	R01CA221290
+geo	GSE165383	T-cell CX3CR1 expression as a dynamic blood-based biomarker of response to immune checkpoint inhibitors	Public on Jan 26, 2021	23-Jan-2021	6-Apr-2021	33658501	UM1CA154967
+geo	GSE165383	T-cell CX3CR1 expression as a dynamic blood-based biomarker of response to immune checkpoint inhibitors	Public on Jan 26, 2021	23-Jan-2021	6-Apr-2021	33658501	R01CA188900
+geo	GSE147250	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	Public on Jun 01, 2020	20-Mar-2020	27-Jul-2021	33658518	U54CA224079
+geo	GSE147250	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	Public on Jun 01, 2020	20-Mar-2020	27-Jul-2021	34244513	R37CA230617
+geo	GSE147250	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	Public on Jun 01, 2020	20-Mar-2020	27-Jul-2021	34244513	U54CA224079
+geo	GSE147940	The Androgen Receptor Directly Regulates CD44 Expression in Androgen Sensitive Bladder Cancer	Public on Mar 21, 2021	1-Apr-2020	21-Mar-2021	33687952	R01CA143971
+geo	GSE147939	The Androgen Receptor Directly Regulates CD44 Expression in Androgen Sensitive Bladder Cancer [ChIP-seq]	Public on Mar 21, 2021	1-Apr-2020	21-Mar-2021	33687952	R01CA143971
+geo	GSE147938	The Androgen Receptor Directly Regulates CD44 Expression in Androgen Sensitive Bladder Cancer [gene expression]	Public on Mar 21, 2021	1-Apr-2020	21-Mar-2021	33687952	R01CA143971
+geo	GSE171442	Regnase-1 suppresses TCF-1+ precursor exhausted T cell formation to limit CAR T cell responses against ALL [WGBS]	Public on Jul 21, 2021	4-Apr-2021	22-Jul-2021	33690816	R01CA221290
+geo	GSE155021	Regnase-1 suppresses TCF-1+ precursor exhausted T cell formation to limit CAR T cell responses against ALL	Public on Apr 07, 2021	23-Jul-2020	23-Jul-2021	33690816	R01CA221290
+geo	GSE155020	Improved persistence and expanded TPEX formation in Regnase-1 KO CAR T cells is TCF-1-dependent	Public on Apr 07, 2021	23-Jul-2020	10-Apr-2021	33690816	R01CA221290
+geo	GSE154942	Regnase-1 KO CAR T cell reprogramed to memory-like cells	Public on Jul 08, 2021	22-Jul-2020	10-Jul-2021	33690816	R01CA221290
+geo	GSE154859	Regnase-1 suppresses TCF-1+ precursor exhausted T cell formation to limit CAR T cell responses against ALL [Microarray Expression]	Public on Jul 08, 2021	21-Jul-2020	10-Jul-2021	33690816	R01CA221290
+geo	GSE151538	T cell receptor repertoire analysis of tumor-infiltrating T cells in non-small cell lung cancer	Public on Mar 11, 2021	1-Jun-2020	23-Mar-2021	33691136	U54CA232568
+geo	GSE151537	T cell receptor repertoire analysis of tumor-infiltrating T cells in non-small cell lung cancer [tumor_T_cells]	Public on Mar 11, 2021	1-Jun-2020	23-Mar-2021	33691136	U54CA232568
+geo	GSE151531	T cell receptor repertoire analysis of tumor-infiltrating T cells in non-small cell lung cancer [tet_sorted_PBLT_cells]	Public on Mar 11, 2021	1-Jun-2020	23-Mar-2021	33691136	U54CA232568
+geo	GSE159907	DNA methylation analysis of acute myeloid leukemia (AML)	Public on Mar 09, 2021	23-Oct-2020	19-May-2021	33707228	U54CA224019
+geo	GSE161650	PolyA-sequencing in Jurkat cells upon CDK12 depletion.	Public on Jan 05, 2021	17-Nov-2020	24-Mar-2021	33753926	P01CA154303
+geo	GSE168453	Longitudinal single-cell epitope and RNA-sequencing reveals the immunological impact of type 1 interferon autoantibodies in critical COVID-19	Public on Mar 09, 2021	8-Mar-2021	6-Apr-2021	33758859	P01AI118688
+geo	GSE158356	Pancreatic cancer is marked by complement-high blood monocytes and tumor-associated macrophages	Public on Mar 24, 2021	22-Sep-2020	12-May-2021	33782087	U01CA224145
+geo	GSE164950	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity	Public on Jan 16, 2021	15-Jan-2021	18-Apr-2021	33795428	U54CA232568
+geo	GSE164949	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [RNA-seq]	Public on Jan 16, 2021	15-Jan-2021	18-Apr-2021	33795428	U54CA232568
+geo	GSE164947	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [ATAC-seq, ChIP-seq]	Public on Jan 16, 2021	15-Jan-2021	18-Apr-2021	33795428	U54CA232568
+geo	GSE164946	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [ATAC-seq]	Public on Jan 16, 2021	15-Jan-2021	18-Apr-2021	33795428	U54CA232568
+geo	GSE142514	Splicing Variation Contributes to Functional Dysregulation of Genes in Acute Myeloid Leukemia	Public on Apr 01, 2021	22-Dec-2019	1-Jul-2021	33876749	U01CA232563
+geo	GSE161466	CRISPR genome editing of human dendritic cells (treatments of knockout dendritic cells)	Public on Apr 27, 2021	13-Nov-2020	1-May-2021	33904395	U54CA224081
+geo	GSE161401	CRISPR genome editing of human dendritic cells (treatments of unedited dendritic cells)	Public on Apr 27, 2021	13-Nov-2020	1-May-2021	33904395	U54CA224081
+geo	GSE169008	Human stem cell-derived pancreatic acini-like and duct-like organoids demonstrate lineage-specific differences to oncogene activation	Public on Apr 16, 2021	16-Mar-2021	2-Jul-2021	33915081	U01CA224193
+geo	GSE167746	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	Public on Mar 27, 2021	26-Feb-2021	19-May-2021	33976133	R01CA208205
+geo	GSE167746	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	Public on Mar 27, 2021	26-Feb-2021	19-May-2021	33976133	U01CA224348
+geo	GSE167746	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	Public on Mar 27, 2021	26-Feb-2021	19-May-2021	33976133	U2CCA233262
+geo	GSE150272	cIAP1/2 antagonism eliminates MHC class I negative tumors through T cell-dependent reprogramming of mononuclear phagocytes	Public on Apr 30, 2021	11-May-2020	30-Jul-2021	34011631	U01CA224146
+geo	GSE150271	cIAP1/2 antagonism eliminates MHC class I negative tumors through T cell-dependent reprogramming of mononuclear phagocytes	Public on Apr 30, 2021	11-May-2020	30-Jul-2021	34011631	U01CA224146
+geo	GSE150270	cIAP1/2 antagonism eliminates MHC class I negative tumors through T cell-dependent reprogramming of mononuclear phagocytes	Public on Apr 30, 2021	11-May-2020	30-Jul-2021	34011631	U01CA224146
+geo	GSE150269	cIAP1/2 antagonism eliminates MHC class I negative tumors through T cell-dependent reprogramming of mononuclear phagocytes	Public on Apr 30, 2021	11-May-2020	30-Jul-2021	34011631	U01CA224146
+geo	GSE158722	Evolution of core archetypal phenotypes in high-grade serous ovarian cancer (HGSOC)	Public on Feb 09, 2021	29-Sep-2020	15-Mar-2022	34031395	U54CA209978
+geo	GSE124230	Pancreatic cancer prognosis is predicted by chromatin accessibility (Quantseq)	Public on Mar 30, 2021	20-Dec-2018	29-Jun-2021	34031415	U01CA224175
+geo	GSE124229	Pancreatic cancer prognosis is predicted by chromatin accessibility (ATAC-Seq)	Public on Mar 30, 2021	20-Dec-2018	29-Jun-2021	34031415	U01CA224175
+geo	GSE160592	Apolipoprotein E promotes immune suppression in pancreatic cancer through NF-kB-mediated production of CXCL1 	Public on May 12, 2021	1-Nov-2020	4-Jun-2021	34049975	U01CA224145
+geo	GSE174711	Dynamic patterns of DNA methylation in the normal prostate epithelial differentiation program are targets of aberrant methylation in prostate cancer [BiSulfite-seq]	Public on Sep 15, 2021	19-May-2021	15-Sep-2021	34075163	U24CA232979
+geo	GSE174662	Dynamic patterns of DNA methylation in the normal prostate epithelial differentiation program are targets of aberrant methylation in prostate cancer [Methyl Capture]	Public on Sep 15, 2021	18-May-2021	15-Sep-2021	34075163	U24CA232979
+geo	GSE174618	Dynamic patterns of DNA methylation in the normal prostate epithelial differentiation program are targets of aberrant methylation in prostate cancer	Public on Sep 15, 2021	18-May-2021	15-Sep-2021	34075163	U24CA232979
+geo	GSE153857	Tumor transcriptomes profiling of SS18-SSX, Smarcb1-/- and combination of SS18-SSX and Smarcb1-/- driven tumor	Public on Jul 01, 2021	6-Jul-2020	30-Sep-2021	34078620	U54CA231652
+geo	GSE153856	RNAseq analysis of synovial sarcoma (SS), Smarcb1-/- and combined genotype of SS18-SSX and Smarcb1-/- mouse tumors	Public on Jul 01, 2021	6-Jul-2020	30-Sep-2021	34078620	U54CA231652
+geo	GSE162664	MOCCASIN: A method for correcting for known and unknown confounders in RNA splicing analysis	Public on Dec 06, 2020	4-Dec-2020	15-Jun-2021	34099673	U01CA232563
+geo	GSE156160	TNF blockade uncouples toxicity and anti-tumor efficacy induced with an agonist CD40 antibody	Public on Sep 08, 2021	13-Aug-2020	8-Sep-2021	34101617	U01CA224193
+geo	GSE159275	PELP1/SRC-3-dependent regulation of metabolic kinases drives therapy resistant ER+ breast cancer [3D]	Public on Apr 01, 2021	8-Oct-2020	1-Jul-2021	34103681	U54CA224076
+geo	GSE126776	MCF-7 cell RNA-seq analysis of PELP1-induced gene expression	Public on Jul 05, 2021	19-Feb-2019	5-Jul-2021	34103681	U54CA224076
+geo	GSE164832	High-fat diet activated fatty acid oxidation mediates intestinal stemness and tumorigenicity	Public on Jun 01, 2021	14-Jan-2021	14-Jul-2021	34107251	U01CA250554
+geo	GSE164832	High-fat diet activated fatty acid oxidation mediates intestinal stemness and tumorigenicity	Public on Jun 01, 2021	14-Jan-2021	14-Jul-2021	34107251	U54CA224068
+geo	GSE165087	Longitudinal single-cell dynamics in chronic lymphocytic leukemia mirror disease history	Public on Jun 09, 2021	19-Jan-2021	13-Jun-2021	34112698	U24CA224331
+geo	GSE163579	Longitudinal single-cell dynamics of mitochondrial mutations in chronic lymphocytic leukemia mirror disease history	Public on Jun 09, 2021	21-Dec-2020	13-Jun-2021	34112698	U24CA224331
+geo	GSE173550	mSWI/SNF promotes polycomb repression both directly and through genome-wide redistribution [ChIP-seq]	Public on Jun 11, 2021	29-Apr-2021	10-Sep-2021	34117481	R01CA163915
+geo	GSE173499	mSWI/SNF promotes polycomb repression both directly and through genome-wide redistribution [RNA-seq]	Public on Jun 11, 2021	28-Apr-2021	10-Sep-2021	34117481	R01CA163915
+geo	GSE145016	mSWI/SNF promotes distal repression by titrating polycomb dosage	Public on Jun 11, 2021	10-Feb-2020	10-Sep-2021	34117481	R01CA163915
+geo	GSE165977	The effect of STAG2 loss in Ewing sarcoma [HiChIP]	Public on May 14, 2021	2-Feb-2021	17-Jul-2021	34129824	R01CA204915
+geo	GSE165783	The effect of STAG2 loss in Ewing sarcoma [ChIP-seq]	Public on May 14, 2021	29-Jan-2021	16-Jun-2021	34129824	R01CA204915
+geo	GSE116495	The effect of STAG2 loss in Ewing sarcoma	Public on May 13, 2021	2-Jul-2018	17-Jul-2021	34129824	R01CA204915
+geo	GSE116494	The effect of STAG2 loss in Ewing sarcoma [ATAC-Seq]	Public on May 14, 2021	2-Jul-2018	16-Jun-2021	34129824	R01CA204915
+geo	GSE116492	The effect of STAG2 loss in Ewing sarcoma [RNA-Seq]	Public on May 14, 2021	2-Jul-2018	16-Jun-2021	34129824	R01CA204915
+geo	GSE152422	Visualizing programmed lineage trajectories at cancer initiation	Public on May 31, 2021	13-Jun-2020	30-Aug-2021	34131071	U24CA209923
+geo	GSE137396	Characterization of transcriptional analysis of LKB1 mutant lung nodules	Public on Mar 17, 2021	13-Sep-2019	20-Jun-2021	34142094	U01CA233084
+geo	GSE137244	Characterization of tumor mutational burden in LKB1 mutant lung tumors	Public on Mar 17, 2021	10-Sep-2019	19-Jun-2021	34142094	U01CA233084
+geo	GSE147877	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	U54CA224079
+geo	GSE147877	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	P50CA186786
+geo	GSE147876	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [RNA-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	U54CA224079
+geo	GSE147876	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [RNA-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	P50CA186786
+geo	GSE147875	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ChIP-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	U54CA224079
+geo	GSE147875	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ChIP-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	P50CA186786
+geo	GSE147874	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ATAC-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	U54CA224079
+geo	GSE147874	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ATAC-seq]	Public on Jun 22, 2021	1-Apr-2020	22-Jun-2021	34145028	P50CA186786
+geo	GSE162256	Spike-in normalization for single-cell RNA-seq reveals dynamic global transcriptional activity mediating anti-cancer drug response	Public on May 25, 2021	27-Nov-2020	26-Jun-2021	34159316	R33CA225323
+geo	GSE174055	Immune checkpoint blockade reprograms systemic immune landscape and tumor microenvironment in obesity-associated breast cancer	Public on May 08, 2021	7-May-2021	30-Jun-2021	34161764	R01CA229164
+geo	GSE174053	Immune checkpoint blockade reprograms systemic immune landscape and tumor microenvironment in obesity-associated breast cancer [tumor]	Public on May 08, 2021	7-May-2021	30-Jun-2021	34161764	R01CA229164
+geo	GSE174044	Immune checkpoint blockade reprograms systemic immune landscape and tumor microenvironment in obesity-associated breast cancer [Mammary fat pad, MFP]	Public on May 08, 2021	7-May-2021	30-Jun-2021	34161764	R01CA229164
+geo	GSE158717	Genome-wide CRISPR rensensitization screens in FGF2 and FL-derived Early and Late Gilteritinib Resistant MOLM14 cultures using Y. Kosuke library	Public on May 19, 2021	29-Sep-2020	18-Aug-2021	34171263	U54CA224019
+geo	GSE161939	Transcriptome Analysis of treated cells in Philadelphia Chromosome-Like Acute Lymphoblastic Leukemia	Public on Sep 22, 2021	21-Nov-2020	22-Sep-2021	34210682	U01CA232486
+geo	GSE174307	10X Genomics single-cell RNAseq combined with CRISPR tiling of Dot1l in mouse MLL-AF9 leukemia	Public on Jun 02, 2021	12-May-2021	27-Jul-2021	34210975	R01CA176745
+geo	GSE176109	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 04, 2021	3-Jun-2021	18-Nov-2021	34215680	R01CA208205
+geo	GSE176109	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 04, 2021	3-Jun-2021	18-Nov-2021	34215680	U01CA224348
+geo	GSE176109	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 04, 2021	3-Jun-2021	18-Nov-2021	34215680	R01AI084880
+geo	GSE175737	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 03, 2021	28-May-2021	18-Nov-2021	34215680	R01CA208205
+geo	GSE175737	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 03, 2021	28-May-2021	18-Nov-2021	34215680	U01CA224348
+geo	GSE175737	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	Public on Jun 03, 2021	28-May-2021	18-Nov-2021	34215680	R01AI084880
+geo	GSE147190	Metabolic control of Tfh and humoral immunity by phosphatidylethanolamine	Public on May 26, 2021	18-Mar-2020	10-Jul-2021	34234346	R01CA221290
+geo	GSE174787	Multiplexed functional genomic analysis of somatic 5’ untranslated region mutations across the spectrum of human prostate cancer (Exome-Seq)	Public on May 20, 2021	20-May-2021	27-Jul-2021	34244513	R37CA230617
+geo	GSE174787	Multiplexed functional genomic analysis of somatic 5’ untranslated region mutations across the spectrum of human prostate cancer (Exome-Seq)	Public on May 20, 2021	20-May-2021	27-Jul-2021	34244513	U54CA224079
+geo	GSE171729	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (RNASeq)	Public on May 17, 2021	8-Apr-2021	27-Jul-2021	34244513	R37CA230617
+geo	GSE171729	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (RNASeq)	Public on May 17, 2021	8-Apr-2021	27-Jul-2021	34244513	U54CA224079
+geo	GSE149489	Multiplexed functional genomic analysis of somatic 5’ untranslated region mutations across the spectrum of human prostate cancer	Public on May 17, 2021	28-Apr-2020	27-Jul-2021	34244513	R37CA230617
+geo	GSE149489	Multiplexed functional genomic analysis of somatic 5’ untranslated region mutations across the spectrum of human prostate cancer	Public on May 17, 2021	28-Apr-2020	27-Jul-2021	34244513	U54CA224079
+geo	GSE149487	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (PLUMAGE)	Public on May 17, 2021	28-Apr-2020	27-Jul-2021	34244513	R37CA230617
+geo	GSE149487	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (PLUMAGE)	Public on May 17, 2021	28-Apr-2020	27-Jul-2021	34244513	U54CA224079
+geo	GSE130465	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (Ribosome Profiling)	Public on May 17, 2021	29-Apr-2019	27-Jul-2021	34244513	R37CA230617
+geo	GSE130465	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (Ribosome Profiling)	Public on May 17, 2021	29-Apr-2019	27-Jul-2021	34244513	U54CA224079
+geo	GSE154747	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells	Public on Jul 13, 2021	20-Jul-2020	12-Oct-2021	34282330	U01DE028227
+geo	GSE154745	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (RNA-seq)	Public on Jul 13, 2021	20-Jul-2020	12-Oct-2021	34282330	U01DE028227
+geo	GSE154743	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (ChIP-seq)	Public on Jul 13, 2021	20-Jul-2020	12-Oct-2021	34282330	U01DE028227
+geo	GSE154742	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (ATAC-seq)	Public on Jul 13, 2021	20-Jul-2020	12-Oct-2021	34282330	U01DE028227
+geo	GSE179694	NUT Carcinoma	Public on Jul 14, 2021	7-Jul-2021	19-Oct-2021	34285087	R01CA124633
+geo	GSE179693	RNA-seq on NUT Carcinoma (NC) cell lines treated with DMSO, Panobinostat or IRBM6	Public on Jul 14, 2021	7-Jul-2021	19-Oct-2021	34285087	R01CA124633
+geo	GSE179692	ChIP-seq analysis of BRD4-NUT and H3K27ac distribution in NUT Carcinoma cell line TC-797 treated with DMSO or Panobinostat	Public on Jul 14, 2021	7-Jul-2021	19-Oct-2021	34285087	R01CA124633
+geo	GSE155698	Multimodal Mapping of the Tumor and Peripheral Blood Immune Landscape in Human Pancreatic Cancer	Public on Oct 01, 2020	4-Aug-2020	28-Jul-2021	34296197	U01CA224145
+geo	GSE173411	Tepoxalin increases chemotherapy efficacy in drug-resistant breast cancer cells overexpressing the multidrug transporter gene ABCB1	Public on Aug 04, 2021	27-Apr-2021	4-Aug-2021	34298440	U54CA209978
+geo	GSE158599	RNA splicing factors SRRM3 and SRRM4 distinguish molecular phenotypes of castration-resistant neuroendocrine prostate cancer	Public on Jul 14, 2021	25-Sep-2020	28-Jul-2021	34312180	P50CA186786
+geo	GSE158598	RNA splicing factors SRRM3 and SRRM4 distinguish molecular phenotypes of castration-resistant neuroendocrine prostate cancer [methylation]	Public on Jul 14, 2021	25-Sep-2020	28-Jul-2021	34312180	P50CA186786
+geo	GSE158593	RNA splicing factors SRRM3 and SRRM4 distinguish molecular phenotypes of castration-resistant neuroendocrine prostate cancer [RNA-seq]	Public on Jul 14, 2021	25-Sep-2020	28-Jul-2021	34312180	P50CA186786
+geo	GSE148248	SMAD4 represses FOSL1 expression and pancreatic cancer metastatic colonization	Public on Aug 02, 2021	7-Apr-2020	2-Aug-2021	34320363	U01CA224146
+geo	GSE150244	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	Public on Jun 30, 2021	11-May-2020	29-Sep-2021	34329586	R01CA204915
+geo	GSE150244	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	Public on Jun 30, 2021	11-May-2020	29-Sep-2021	34329586	U54CA231637
+geo	GSE150244	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	Public on Jun 30, 2021	11-May-2020	29-Sep-2021	34329586	U54CA231641
+geo	GSE148495	Generation of a functional, patient specific human thymus from induced pluripotent stem cell in vivo	Public on Sep 24, 2021	10-Apr-2020	25-Oct-2021	34331993	R01CA213102
+geo	GSE179111	CXCR6 Positions Cytotoxic T Cells to Receive Critical Survival Signals in the Tumor Microenvironment	Public on Jun 30, 2021	29-Jun-2021	29-Sep-2021	34343496	R01AI084880
+geo	GSE157830	Labile Iron Release Primes Pancreatic Cancer for Ferroptosis	Public on Jun 03, 2021	11-Sep-2020	8-Sep-2021	34381026	U01CA224145
+geo	GSE178388	Downregulation of exhausted cytotoxic T cells in gene expression networks of multisystem inflammatory syndrome in children	Public on Jun 18, 2021	17-Jun-2021	17-Sep-2021	34381049	U01DK124165
+geo	GSE178388	Downregulation of exhausted cytotoxic T cells in gene expression networks of multisystem inflammatory syndrome in children	Public on Jun 18, 2021	17-Jun-2021	17-Sep-2021	34381049	U24CA224319
+geo	GSE181374	RNA-Seq of MSK-PCa series of Patient Derived Organoids and Xenografts	Public on Aug 04, 2021	3-Aug-2021	22-Mar-2022	34417459	R37CA230617
+geo	GSE181374	RNA-Seq of MSK-PCa series of Patient Derived Organoids and Xenografts	Public on Aug 04, 2021	3-Aug-2021	22-Mar-2022	34417459	U54CA224079
+geo	GSE165851	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [TCR-seq]	Public on Aug 26, 2021	31-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE165850	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [BCR-seq]	Public on Aug 26, 2021	31-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE165822	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [CITE-seq]	Public on Aug 26, 2021	29-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE165499	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case	Public on Aug 26, 2021	25-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE165496	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [RNA-seq]	Public on Aug 26, 2021	25-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE165397	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [ATAC-seq]	Public on Aug 26, 2021	24-Jan-2021	25-Nov-2021	34432868	U24CA224331
+geo	GSE178341	A Single Cell Atlas of MMRd and MMRp Colorectal Cancer	Public on Aug 26, 2021	16-Jun-2021	2-Sep-2021	34450029	U01CA224146
+geo	GSE178341	A Single Cell Atlas of MMRd and MMRp Colorectal Cancer	Public on Aug 26, 2021	16-Jun-2021	2-Sep-2021	34450029	U2CCA233195
+geo	GSE178341	A Single Cell Atlas of MMRd and MMRp Colorectal Cancer	Public on Aug 26, 2021	16-Jun-2021	2-Sep-2021	34450029	U54CA224068
+geo	GSE92765	LPAR signaling activated in neural crest stem cells promotes melanoma cell growth, invasion and therapy resistance	Public on Dec 01, 2017	22-Dec-2016	27-Oct-2021	34462276	U54CA224070
+geo	GSE92764	LPAR signaling activated in neural crest stem cells promotes melanoma cell growth, invasion and therapy resistance [HumanHT-12 V4.0]	Public on Dec 01, 2017	22-Dec-2016	27-Oct-2021	34462276	U54CA224070
+geo	GSE92763	LPAR signaling activated in neural crest stem cells promotes melanoma cell growth, invasion and therapy resistance [HumanWG6_V2]	Public on Dec 01, 2017	22-Dec-2016	27-Oct-2021	34462276	U54CA224070
+geo	GSE175715	YBX1 mediates translation of oncogenic transcripts to control cell competition in AML	Public on May 28, 2021	27-May-2021	7-Sep-2021	34465866	R01CA176745
+geo	GSE175714	YBX1 mediates translation of oncogenic transcripts to control cell competition in AML [RNA-seq polysomes]	Public on May 28, 2021	27-May-2021	7-Sep-2021	34465866	R01CA176745
+geo	GSE175713	YBX1 mediates translation of oncogenic transcripts to control cell competition in AML [RNA-seq]	Public on May 28, 2021	27-May-2021	7-Sep-2021	34465866	R01CA176745
+geo	GSE175712	YBX1 mediates translation of oncogenic transcripts to control cell competition in AML [ChIP-seq]	Public on May 28, 2021	27-May-2021	7-Sep-2021	34465866	R01CA176745
+geo	GSE180949	Dietary suppression of MHC-II expression in intestinal epithelial cells enhances intestinal tumorigenesis	Public on Aug 16, 2021	27-Jul-2021	15-Nov-2021	34529935	U01CA250554
+geo	GSE143805	Transcriptional profiling of distinct fibroblast populations in the pancreatic tumor microenvironment	Public on Sep 16, 2021	16-Jan-2020	16-Dec-2021	34548310	U01CA224193
+geo	GSE171837	Bortezomib induces anti-multiple myeloma immune response mediated by cGAS/STING pathway activation	Public on Apr 12, 2021	11-Apr-2021	29-Sep-2021	34568832	P01CA155258
+geo	GSE162515	Chromatin accessibility associates with protein-RNA correlation in human cancer	Public on Dec 03, 2020	2-Dec-2020	15-Oct-2021	34593797	U2CCA233311
+geo	GSE181817	Atlas of Clinically Distinct Cell States and Cellular Ecosystems Across Human Solid Tumors	Public on Aug 12, 2021	10-Aug-2021	14-Oct-2021	34597583	U24CA224309
+geo	GSE182436	The Landscape of Tumor Cell States and Ecosystems in Diffuse Large B Cell Lymphoma	Public on Sep 30, 2021	19-Aug-2021	14-Oct-2021	34597589	U24CA224309
+geo	GSE182435	The Landscape of Tumor Cell States and Ecosystems in Diffuse Large B Cell Lymphoma [scVDJ-seq]	Public on Sep 30, 2021	19-Aug-2021	14-Oct-2021	34597589	U24CA224309
+geo	GSE182434	The Landscape of Tumor Cell States and Ecosystems in Diffuse Large B Cell Lymphoma [scRNA-seq]	Public on Sep 30, 2021	19-Aug-2021	14-Oct-2021	34597589	U24CA224309
+geo	GSE168204	Pathway Signatures Derived from On-treatment Tumor Specimens Predict Response to Anti-PD1 Blockade in Metastatic Melanoma	Public on Aug 15, 2021	3-Mar-2021	21-Oct-2021	34654806	U54CA224070
+geo	GSE167042	Splicing modulation increases BCL2 dependence and sensitizes Multiple Myeloma cells to Venetoclax	Public on Feb 08, 2022	18-Feb-2021	9-Feb-2022	34670358	P01CA155258
+geo	GSE156788	Increased ACTL6A Occupancy Within mSWI/SNF Chromatin Remodelers Drives Human Squamous Cell Carcinoma	Public on Oct 29, 2021	24-Aug-2020	31-Oct-2021	34687603	R01CA163915
+geo	GSE156787	Altered BAF53A (ACTL6A) Stoichiometry Drives Human Squamous Cell Carcinoma [CnR]	Public on Oct 29, 2021	24-Aug-2020	28-Jan-2022	34687603	R01CA163915
+geo	GSE156786	Altered BAF53A (ACTL6A) Stoichiometry Drives Human Squamous Cell Carcinoma [ATAC-seq]	Public on Oct 29, 2021	24-Aug-2020	28-Jan-2022	34687603	R01CA163915
+geo	GSE156785	Altered BAF53A (ACTL6A) Stoichiometry Drives Human Squamous Cell Carcinoma [RNA-seq]	Public on Oct 29, 2021	24-Aug-2020	28-Jan-2022	34687603	R01CA163915
+geo	GSE158724	Convergent evolution of resistance pathways during early stage breast cancer treatment with combination cell cycle (CDK) and endocrine signalling inhibitors 	Public on Feb 09, 2021	29-Sep-2020	6-Dec-2021	34712959	U54CA209978
+geo	GSE148808	Potent androgen receptor inhibition unleashes oncogenic action of the KLF5 stem cell transcription factor in castration-resistant prostate cancer	Public on Sep 21, 2021	16-Apr-2020	29-Dec-2021	34737261	R37CA230617
+geo	GSE148807	Potent androgen receptor inhibition unleashes oncogenic action of the KLF5 stem cell transcription factor in castration-resistant prostate cancer [ChIP-seq]	Public on Sep 21, 2021	16-Apr-2020	29-Dec-2021	34737261	R37CA230617
+geo	GSE148806	Potent androgen receptor inhibition unleashes oncogenic action of the KLF5 stem cell transcription factor in castration-resistant prostate cancer [RNA-seq]	Public on Sep 21, 2021	16-Apr-2020	29-Dec-2021	34737261	R37CA230617
+geo	GSE176282	Single-cell Multi-omics Defines Tolerogenic Extrathymic Aire-Expressing Populations with Unique Homology to Thymic Epithelium	Public on Dec 15, 2021	7-Jun-2021	15-Dec-2021	34767455	P01AI118688
+geo	GSE188241	H3K27 tri-methylation signature in CML CD34+ cells	Public on Nov 08, 2021	4-Nov-2021	7-Feb-2022	34780648	R01CA229875
+geo	GSE164506	Exceptional response of high-risk neuroblastoma to RBM39 degrader Indisulam	Public on Nov 24, 2021	10-Jan-2021	25-Nov-2021	34788094	U01CA232488
+geo	GSE164505	Exceptional response of high-risk neuroblastoma to RBM39 degrader Indisulam (RNA-Seq)	Public on Nov 24, 2021	10-Jan-2021	25-Nov-2021	34788094	U01CA232488
+geo	GSE164504	Exceptional response of high-risk neuroblastoma to RBM39 degrader Indisulam (ATAC-Seq)	Public on Nov 24, 2021	10-Jan-2021	25-Nov-2021	34788094	U01CA232488
+geo	GSE162137	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma 	Public on Sep 17, 2021	25-Nov-2020	10-Dec-2021	34795254	U2CCA233195
+geo	GSE162137	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma 	Public on Sep 17, 2021	25-Nov-2020	10-Dec-2021	34795254	U2CCA233238
+geo	GSE162137	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma 	Public on Sep 17, 2021	25-Nov-2020	10-Dec-2021	34795254	UM1CA154967
+geo	GSE152885	Predicting master transcription factors from pan-cancer expression data	Public on Sep 15, 2021	20-Jun-2020	15-Dec-2021	34818047	P01CA155258
+geo	GSE150443	Predicting Master Transcription Factors from Pan-Cancer Expression Data	Public on Apr 19, 2021	12-May-2020	15-Dec-2021	34818047	P01CA155258
+geo	GSE183210	Phenotypic consequences of SLC25A40-ABCB1 fusions beyond drug resistance in High Grade Serous Ovarian Cancer	Public on Sep 03, 2021	1-Sep-2021	3-Dec-2021	34830797	U54CA209978
+geo	GSE160174	Induction of T cell dysfunction and NK-like T cell differentiation in vitro and in patients after CAR T cell treatment	Public on Dec 06, 2021	26-Oct-2020	8-Dec-2021	34861191	P01CA214278
+geo	GSE185621	Phase Separation by the NUP98-HOXA9 Fusion Oncoprotein Drives an Oncogenic Phenotype in Hematopoietic Cells	Public on Oct 13, 2021	10-Oct-2021	17-Dec-2021	34903620	U54CA243124
+geo	GSE184398	RNA-sequencing of tumor infiltrating cells across 12 different solid tumors type	Public on Dec 29, 2021	19-Sep-2021	1-Jan-2022	34963056	R01CA197363
+geo	GSE184398	RNA-sequencing of tumor infiltrating cells across 12 different solid tumors type	Public on Dec 29, 2021	19-Sep-2021	1-Jan-2022	34963056	U54CA224081
+geo	GSE180599	MUC1-C DICTATES JUN AND BAF-MEDIATED CHROMATIN REMODELING AT PROMOTER AND ENHANCER SIGNATURES IN CANCER STEM CELLS	Public on Jan 19, 2022	21-Jul-2021	22-Jan-2022	35022313	U01CA233084
+geo	GSE180599	MUC1-C DICTATES JUN AND BAF-MEDIATED CHROMATIN REMODELING AT PROMOTER AND ENHANCER SIGNATURES IN CANCER STEM CELLS	Public on Jan 19, 2022	21-Jul-2021	22-Jan-2022	35022313	U24CA232979
+geo	GSE196435	Insufficiency of compound immune checkpoint blockade to overcome engineered T cell exhaustion in pancreatic cancer	Public on Mar 01, 2022	9-Feb-2022	30-Mar-2022	35210305	U01CA224193
+geo	GSE178239	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	R01CA241452
+geo	GSE178239	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	U10CA180899
+geo	GSE178238	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-ChIP-Seq	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	R01CA241452
+geo	GSE178238	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-ChIP-Seq	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	U10CA180899
+geo	GSE178237	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-RNA-Seq	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	R01CA241452
+geo	GSE178237	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-RNA-Seq	Public on Dec 31, 2021	15-Jun-2021	1-Apr-2022	34166225	U10CA180899
+geo	GSE168884	Affymetrix OncoScan SNP data for T-cell lymphoblastic lymphoma	Public on Mar 15, 2021	14-Mar-2021	11-Aug-2021	34297047	U10CA180899
+geo	GSE168884	Affymetrix OncoScan SNP data for T-cell lymphoblastic lymphoma	Public on Mar 15, 2021	14-Mar-2021	11-Aug-2021	34297047	U24CA196173
+geo	GSE175543	Comprehensive molecular characterization of pediatric radiation-induced high-grade glioma	Public on May 27, 2021	25-May-2021	13-Oct-2021	34545084	U24CA055727
+geo	GSE151506	Epigenetic encoding, heritability and plasticity of glioma transcriptional cell states	Public on May 31, 2021	30-May-2020	7-Jan-2022	34594037	K12CA090354
+geo	GSE186150	scRNAseq of longitidunally acquired samples from a CLL patient	Public on Oct 22, 2021	19-Oct-2021	21-Jan-2022	34711268	U24CA209999
+geo	GSE184717	Novel temporal and spatial patterns of metastatic colonization from breast cancer rapid-autopsy tumor biopsies	Public on Sep 26, 2021	24-Sep-2021	4-Nov-2021	34711268	U24CA209999
+geo	GSE188325	CD19-CAR T cells undergo exhaustion epigenetic programming in patients with acute lymphoblastic leukemia	Public on Nov 08, 2021	5-Nov-2021	7-Feb-2022	34852226	F32CA250155
+geo	GSE186802	GD2-CAR T-cell therapy for H3K27M-mutated diffuse midline gliomas	Public on Feb 07, 2022	29-Oct-2021	1-Apr-2022	35130560	R01CA263500
+geo	GSE190269	Transcriptomic data of cord blood CD34+ cells as controls of transcriptome cohort of pediatric acute myeloid leukemia	Public on Feb 22, 2022	6-Dec-2021	22-Feb-2022	35176137	U10CA180899
+geo	GSE189901	Expression data from cord blood CD34+ cells transduced with UBTF wildtype expression vectors, UBTF-TD expression vectors, or empty control vector.	Public on Feb 22, 2022	30-Nov-2021	22-Feb-2022	35176137	U10CA180899
+geo	GSE195620	Multi-omics analysis of RNA binding, splicing and turnover alterations induced by mutant U2AF1 in myeloid malignancies.	Public on Mar 17, 2022	28-Jan-2022	28-Mar-2022	35303483	R01CA222518

--- a/digest_data/digest_sra.tsv
+++ b/digest_data/digest_sra.tsv
@@ -1,0 +1,455 @@
+type	accession	study_title	bioproject_accession	registration_date	publication_id	queried_project_id
+sra	SRP097738	esBAF chromatin remodeling complexes promote spacing of nucleosomes flanking pluripotency factor binding sites	PRJNA368640	25-Jan-2017	28250416	R01CA163915
+sra	SRP097737	TOP2 synergizes with BAF chromatin remodeling for resolution of facultative heterochromatin	PRJNA368641	25-Jan-2017	28250416	R01CA163915
+sra	SRP091873	Reconstituting development of pancreatic intraepithelial neoplasia from primary human pancreas duct cells	PRJNA349475	20-Oct-2016	28272465	R01CA211927
+sra	SRP102091	Chromatin-associated protein interactions drive megadomain formation in NUT midline carcinoma	PRJNA379616	17-Mar-2017	28484033	R01CA124633
+sra	SRP096375	Gene expression profile of human multiple myeloma cell line MM.1S after knockdown of KDM6B	PRJNA360859	10-Jan-2017	28487543	P01CA155258
+sra	SRP106708	Analysis of gene expression in p53-null cell types following deletion of Mdm2	PRJNA385963	9-May-2017	28576884	R01CA181204
+sra	SRP108222	AR-independent prostate cancer is sustained through FGF signaling	PRJNA388341	29-May-2017	29017058	U54CA224079
+sra	SRP094781	Molecular portraits of tumor mutational and micro-environmental sculpting by immune checkpoint blockade therapy	PRJNA356761	8-Dec-2016	29033130	R01CA205426
+sra	SRP092083	Suppression of adaptive responses to targeted cancer therapy by transcriptional repression [ChIP-seq]	PRJNA350359	24-Oct-2016	29054992	P01CA154303
+sra	SRP064353	RNA-Seq data for AKT, BAD, ERBB2, IGF1R, RAF1 and ERK1 over-expressed samples with twelve green fluorescent protein control samples using human mammary epithelial cells	PRJNA297451	30-Sep-2015	29093439	U54CA209978
+sra	SRP092523	Single-cell profiling of tumor infiltrating T cells	PRJNA352336	3-Nov-2016	29101163	P01CA154303
+sra	SRP081517	Expression profile of HNF1A knockdown and overexpression in 22RV1 and LNCaP cells respectively	PRJNA338785	12-Aug-2016	29153843	U54CA224079
+sra	SRP081515	Expression profile of LNCaP/AR cells with or without HNF4G expression grown for long term in charcoal stripped-serum (CSS) media	PRJNA338786	12-Aug-2016	29153843	U54CA224079
+sra	SRP081514	HNF4G, AR, FOXA1, H3K4me1, H3K27acetyl binding sites upon knockdown and overexpression of HNF4G in 22Rv1 and LNCaP prostate cancer cells respectively	PRJNA338787	12-Aug-2016	29153843	U54CA224079
+sra	SRP118933	Osteoblasts remotely supply lung tumors with cancer-promoting SiglecFhigh neutrophils	PRJNA412257	26-Sep-2017	29191879	R01AI084880
+sra	SRP125486	How HLA influences response to immunotherapy (Part 3)	PRJNA419530	22-Nov-2017	29217585	R01CA205426
+sra	SRP199253	A major chromatin regulator determines resistance of tumor cells to T cell–mediated killing	PRJNA544340	22-May-2019	29301958	U24CA224316
+sra	SRP126091	A Major Chromatin Regulator Determines Resistance of Tumor Cells to T cell Mediated Killing	PRJNA420997	4-Dec-2017	29301958	U24CA224316
+sra	SRP125218	Peptidomimetic blockade of MYB in acute myeloid leukemia [H3K27ac ChIP-seq]	PRJNA418963	17-Nov-2017	29317678	R01CA204396
+sra	SRP098166	Peptidomimetic blockade of MYB in acute myeloid leukemia [RNA-seq]	PRJNA369119	27-Jan-2017	29317678	R01CA204396
+sra	SRP120988	Analysis of genome-wide accessibility following acute deletion of Ring1b in mouse embryonic stem cells [ATAC-seq]	PRJNA415436	23-Oct-2017	29323272	R01CA163915
+sra	SRP106553	Effects of dominant-negative G784E Smarca4 mutation on enhancer marks and factors in mouse embryonic stem cells [ChIP-seq]	PRJNA385663	5-May-2017	29323272	R01CA163915
+sra	SRP106196	Effects of dominant-negative Smarca4 mutations on the DNA accessibility landscape [ATAC-seq]	PRJNA385199	2-May-2017	29323272	R01CA163915
+sra	SRP115262	Rheostatic Chromatin Control of Promiscuous Transcription by Aire and Brg1 [ATAC-Seq]	PRJNA397970	11-Aug-2017	29335648	R01CA163915
+sra	SRP073740	Transcriptional effect of ETV1 knockdown in melanoma cells	PRJNA319396	15-Apr-2016	29360641	U54CA224079
+sra	SRP073739	ETV1 binding sites in GIST and Melanoma cells	PRJNA319395	19-Apr-2016	29360641	U54CA224079
+sra	SRP073337	Role of COP1 on MAP kinase transcriptional output in melanoma	PRJNA318531	14-Apr-2016	29360641	U54CA224079
+sra	SRP073110	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [ChIP-seq]	PRJNA318044	11-Apr-2016	29379199	P01CA155258
+sra	SRP125209	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia [ATAC-seq]	PRJNA418959	17-Nov-2017	29431698	R01CA204396
+sra	SRP125208	MEF2C phosphorylation is required for chemotherapy resistance in acute myeloid leukemia [inhibitor MRT199665]	PRJNA418960	17-Nov-2017	29431698	R01CA204396
+sra	SRP102810	High-efficiency RNA-based reprogramming of human primary fibroblasts	PRJNA381150	31-Mar-2017	29467427	R01AI124487
+sra	SRP090392	BRCA1/RNApII regulation in Ewing''s sarcoma (ChIP-seq)	PRJNA344334	23-Sep-2016	29513652	R01CA204915
+sra	SRP130991	mRNA profiles in PAF KO intestinal adenoma	PRJNA430110	15-Jan-2018	29533773	P50CA098258
+sra	SRP110503	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [ATAC-seq]	PRJNA391904	26-Jun-2017	29535300	R01CA204136
+sra	SRP110502	Epigenomic analysis of Atrx deficiency in murine glioma cells of orgin [Atrx ChIP]	PRJNA391902	26-Jun-2017	29535300	R01CA204136
+sra	SRP133767	Widespread intronic polyadenylation diversifies immune cell transcriptomes	PRJNA436569	1-Mar-2018	29712909	P01CA155258
+sra	SRP092637	Genome-wide gene-expression profile of mouse intestinal stem cells	PRJNA352598	5-Nov-2016	29727683	U54CA224068
+sra	SRP133187	RNA-seq profiling identifies Androgen Receptor-regulated genes in prostate cancer cells	PRJNA434757	20-Feb-2018	29808028	P50CA186786
+sra	SRP117692	TMPRSS2-ERG suppresses PTEN/TP53 alteration-induced cancer lineage plasticity	PRJNA407356	14-Sep-2017	29844131	U54CA224079
+sra	SRP136348	Disruption of TET-2 promotes the therapeutic efficacy of CD19-targeted T-cells	PRJNA445447	23-Mar-2018	29849141	P01CA214278
+sra	SRP142614	RNA-seq of CD33 KO and control HSPCs	PRJNA453558	25-Apr-2018	29856956	P01CA214278
+sra	SRP137894	Methylation profile of neuroendocrine prostate cancer models	PRJNA449098	6-Apr-2018	29921838	U54CA224079
+sra	SRP137893	Molecular characterization of neuroendocrine prostate cancer organoids and PDOX by RNA-seq	PRJNA449096	5-Apr-2018	29921838	U54CA224079
+sra	SRP139944	Critical role for Lymphocytes in Producing FLT3LG in Tumors and Driving Checkpoint Therapy-Receptive Immune Microenvironments	PRJNA450084	13-Apr-2018	29942093	R01CA197363
+sra	SRP139554	Metabolic signaling directs the reciprocal lineage decisions of aß and ?d T cells	PRJNA449676	11-Apr-2018	29980617	R01CA221290
+sra	SRP098949	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: synthetic ratiometric pools	PRJNA371517	6-Feb-2017	30010675	P50CA186786
+sra	SRP148788	Pancreatic islets communicate with lymphoid tissues via exocytosis of insulin peptides	PRJNA472771	23-May-2018	30022165	P01AI118688
+sra	SRP148866	Tumor innate immunity primed by specific interferon-stimulated endogenous retroviruses (ATAC-seq)	PRJNA472897	24-May-2018	30038220	U01CA217885
+sra	SRP148173	Therapeutic efficacy of BET bromodomain protein inhhibitor and PD-1 blockade in genetically engineered mouse model of non-small cell lung cancer	PRJNA471887	17-May-2018	30087114	P01CA154303
+sra	SRP150548	Robust prediction of response to immune checkpoint blockade therapy in metastatic melanoma	PRJNA476140	14-Jun-2018	30127394	R33CA225291
+sra	SRP150548	Robust prediction of response to immune checkpoint blockade therapy in metastatic melanoma	PRJNA476140	14-Jun-2018	30127394	U54CA224070
+sra	SRP153810	Discovery of a Pro-Tumoral Clonogenic Unipotent Neutrophil Progenitor in Mouse and Human Bone Marrow	PRJNA481252	16-Jul-2018	30157427	U01CA224766
+sra	SRP153808	Identification of an Early Unipotent Neutrophil Progenitor with Pro-Tumoral Activity in Mouse and Human Bone Marrow	PRJNA481247	16-Jul-2018	30157427	U01CA224766
+sra	SRP144074	Transcriptional effects of small molecule targeting of ARID1A	PRJNA454308	30-Apr-2018	30197195	R01CA163915
+sra	SRP102097	Genome-wide maps of histone H3K27 acetylation in A549 and MSR-A549 cells.	PRJNA379622	17-Mar-2017	30205046	U01CA217885
+sra	SRP102097	Genome-wide maps of histone H3K27 acetylation in A549 and MSR-A549 cells.	PRJNA379622	17-Mar-2017	30205046	P01CA154303
+sra	SRP102140	mRNA expression profile of A549 cells and MSR-A549 cells with or without JQ1 treatment	PRJNA379664	17-Mar-2017	30205046	U01CA217885
+sra	SRP102140	mRNA expression profile of A549 cells and MSR-A549 cells with or without JQ1 treatment	PRJNA379664	17-Mar-2017	30205046	P01CA154303
+sra	SRP092620	Inhibition of MEK and ATR induces synergistic killing of a Mll-Af4 B-ALL model harboring activated Ras mutation	PRJNA352549	4-Nov-2016	30266823	R01CA176745
+sra	SRP123227	Transcript analysis of CD45+Ter119+CD71+ erythroid-like progenitor cells from tumor-bearing mice	PRJNA416659	31-Oct-2017	30297899	R33CA225328
+sra	SRP154583	Differences in microRNA expression in breast cancer between women of African and European ancestry	PRJNA482141	20-Jul-2018	30321299	U24CA232979
+sra	SRP155033	Colonic adenoma and adjacent normal single-cell RNA-seq	PRJNA482649	24-Jul-2018	30346945	U2CCA233291
+sra	SRP144614	Colonic single-cell RNA-seq experiment	PRJNA461797	4-May-2018	30346945	U2CCA233291
+sra	SRP132307	Differential Gene expression in the mouse mammary tumors of PyMT-Malat1 wild-type (WT), PyMT-Malat1 knockout (KO) and PyMT-Malat1 knockout with Malat1 transgene expression (TG)	PRJNA433234	6-Feb-2018	30349115	U24CA209851
+sra	SRP150315	Bone marrow derived human B cells [normal proB]	PRJNA475684	12-Jun-2018	30357359	U01CA232563
+sra	SRP150314	Aberrant splicing in B-cell acute lymphoblastic leukemia [cell line]	PRJNA475682	12-Jun-2018	30357359	U01CA232563
+sra	SRP123595	T helper cells modulate intestinal stem cell renewal and differentiation	PRJNA417070	3-Nov-2017	30392957	U54CA224068
+sra	SRP140441	Elucidating the role of glycogen debranching enzyme AGL in bladder carcinogenesis by generation and characterization of knockout mice	PRJNA450320	16-Apr-2018	30403777	R01CA143971
+sra	SRP162041	Targeting the CALR Interactome in Myeloproliferative Neoplasms	PRJNA491714	18-Sep-2018	30429377	R01CA204396
+sra	SRP140587	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [ChIP-seq]	PRJNA450476	16-Apr-2018	30431433	R01CA204915
+sra	SRP140587	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [ChIP-seq]	PRJNA450476	16-Apr-2018	30431433	R01CA176745
+sra	SRP140586	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [RNA-seq]	PRJNA450466	16-Apr-2018	30431433	R01CA204915
+sra	SRP140586	Targeted degradation of BRD9 reverses oncogenic gene expression in synovial sarcoma [RNA-seq]	PRJNA450466	16-Apr-2018	30431433	R01CA176745
+sra	SRP149518	Evaluating pre-clinical models for studying NASH driven HCC.	PRJNA474086	1-Jun-2018	30449681	U01AA027681
+sra	SRP161930	Lung adenocarcinoma UNC0638 gene expression	PRJNA491480	17-Sep-2018	30455465	P01CA154303
+sra	SRP141216	H3K9 methyltransferases and demethylases control lung tumor-propagating cells and lung cancer progression (experiment 2)	PRJNA451026	19-Apr-2018	30455465	P01CA154303
+sra	SRP162854	IKZF2 is required for myeloid leukemic stem cells by driving self-renewal and inhibiting the myeloid differentiation program II	PRJNA493794	28-Sep-2018	30472158	R01CA176745
+sra	SRP127266	IKZF2 is required for myeloid leukemic stem cells by driving self-renewal and inhibiting the myeloid differentiation program I	PRJNA423273	20-Dec-2017	30472158	R01CA176745
+sra	SRP133326	Single cell RNA-seq of IL-10-producing CD4 T cells during chronic LCMV infection	PRJNA435611	22-Feb-2018	30487586	R01CA203923
+sra	SRP133325	RNA-seq of Tfh IL21+ single producers and Tfh IL21+ IL10+ double producers	PRJNA435612	22-Feb-2018	30487586	R01CA203923
+sra	SRP133828	Organoid modeling of the tumor immune microenvironment	PRJNA436710	2-Mar-2018	30550791	U54CA224081
+sra	SRP139591	Transcript analysis of multi-locus sampled tumor tissue in patients with non-small cell lung cancer	PRJNA449697	11-Apr-2018	30560866	R33CA225328
+sra	SRP166318	Metabolic heterogeneity underlies reciprocal fates of TH17 cell stemness and plasticity [scRNA-seq]	PRJNA497860	22-Oct-2018	30568299	R01CA221290
+sra	SRP166317	Metabolic heterogeneity underlies reciprocal fates of TH17 cell stemness and plasticity [ATAC-seq]	PRJNA497861	22-Oct-2018	30568299	R01CA221290
+sra	SRP167870	Identification of ADAR1 adenosine deaminase dependency in a subset of cancer cells	PRJNA503859	5-Nov-2018	30575730	P01CA154303
+sra	SRP073902	Non-overlapping control of transcriptome by Promoter and Super-Enhancer-Associated Dependencies	PRJNA319620	26-Apr-2016	30590042	P01CA155258
+sra	SRP151196	Homolog-selective degradation as a strategy to probe the function of CDK6 in AML	PRJNA477657	23-Jun-2018	30595531	P01CA154303
+sra	SRP165173	SHP2 Drives Adaptive Resistance to ERK Signaling Inhibition in Molecularly Defined Subsets of ERK-dependent Tumors	PRJNA495756	11-Oct-2018	30605687	R01CA204314
+sra	SRP158590	Molecular Signatures of Multiple Myeloma Progression through Single Cell RNA-Seq	PRJNA487220	22-Aug-2018	30607001	U54CA224018
+sra	SRP139047	Arg1 expression defines immunosuppressive subsets of immune infiltrating cells in cancer	PRJNA449347	9-Apr-2018	30613266	R01AI084880
+sra	SRP140568	Enhancer Domains in Gastrointestinal Stromal Tumor Regulate KIT Expression and are Targetable by BET Bromodomain Inhibition [RNA-seq]	PRJNA450436	16-Apr-2018	30630822	R01CA176745
+sra	SRP140559	Enhancer Domains in Gastrointestinal Stromal Tumor Regulate KIT Expression and are Targetable by BET Bromodomain Inhibition [ChIP-seq]	PRJNA450432	16-Apr-2018	30630822	R01CA176745
+sra	SRP101890	Neuronal brain region-specific DNA methylation and chromatin accessibility are associated with neuropsychiatric trait heritability [RNA-Seq]	PRJNA379175	14-Mar-2017	30643296	U24CA180996
+sra	SRP163059	GREB1 amplifies androgen receptor output in prostate cancer and contributes to antiandrogen resistance	PRJNA494242	1-Oct-2018	30644358	U54CA224079
+sra	SRP163001	GREB1 amplifies androgen receptor output in prostate cancer and contributes to antiandrogen resistance	PRJNA494088	1-Oct-2018	30644358	U54CA224079
+sra	SRP159024	Targeting the perivascular niche sensitizes disseminated tumour cells to chemotherapy	PRJNA488272	28-Aug-2018	30664790	U54CA224079
+sra	SRP166553	Clonal deletion of tumor-specific T cells by IFN-g confers therapeutic resistance to combination immune checkpoint blockade	PRJNA498104	23-Oct-2018	30737146	U01CA233100
+sra	SRP159013	Gene exression in single T cells across division states.	PRJNA488249	28-Aug-2018	30742126	U24CA224309
+sra	SRP108831	Genome-wide maps at the base-pair level, of chromatin regions enriched for H3 me3 marks in mouse glioma neurospheres (NS)	PRJNA389684	8-Jun-2017	30760578	U01CA224160
+sra	SRP100060	Differential gene expression in IDH1-R132H Low Grade Glioma animal brain tumors brain in response to 10 Gy of radiation	PRJNA375076	16-Feb-2017	30760578	U01CA224160
+sra	SRP158518	SOX2 epidermal overexpression promotes cutaneous wound healing via activation of EGFR/MEK/ERK signaling mediated by EGFR ligands	PRJNA487061	21-Aug-2018	30772301	R33CA225291
+sra	SRP147456	Mitochondrial hypoxic stress induces RNA editing by APOBEC3G in lymphocytes	PRJNA471680	16-May-2018	30791937	U24CA232979
+sra	SRP147456	Mitochondrial hypoxic stress induces RNA editing by APOBEC3G in lymphocytes	PRJNA471680	16-May-2018	30791937	R01CA188900
+sra	SRP173344	Nr4a transcription factors limit CAR-T cell function in solid tumors [RNA-Seq]	PRJNA509668	12-Dec-2018	30814732	U01DE028227
+sra	SRP183188	Single-cell RNA-seq reveals AML hierarchies relevant to disease progression and immunity	PRJNA477870	25-Jun-2018	30827681	U2CCA233195
+sra	SRP162488	Regulatory T cell depletion promotes oncogenic Kras driven pancreatic tumorigenesis.	PRJNA492936	24-Sep-2018	30827862	U01CA224145
+sra	SRP162488	Regulatory T cell depletion promotes oncogenic Kras driven pancreatic tumorigenesis.	PRJNA492936	24-Sep-2018	31911451	U01CA224145
+sra	SRP187956	Combined inhibition of STAT3 and DNA repair in palbociclib-resistant ER-positive breast cancer	PRJNA526217	8-Mar-2019	30867218	R01AI109294
+sra	SRP137885	The gene expression profiles of antigen-primed wildtype and Ddit3-/- CD8 Pmel T cells	PRJNA449089	6-Apr-2018	30894532	U01CA232758
+sra	SRP168621	Transcriptomic analysis to functionally map the intrinsically disordered domain of EWS/FLI [Experiment 1]	PRJNA505501	14-Nov-2018	30899417	U54CA231641
+sra	SRP168620	Transcriptomic analysis to functionally map the intrinsically disordered domain of EWS/FLI [Experiment 2]	PRJNA505502	14-Nov-2018	30899417	U54CA231641
+sra	SRP075249	PTEN-deficient synovial sarcoma	PRJNA321740	16-May-2016	30909651	U54CA231652
+sra	SRP326507	Functional and Mechanistic Interrogation of BET Bromodomain Degraders for the Treatment of Metastatic Castration-resistant Prostate Cancer	PRJNA743059	1-Jul-2021	30918020	P50CA186786
+sra	SRP136023	Prostate Cancer Cell RNA-Seq (PC3E and GS689.Li)	PRJNA438990	19-Mar-2018	30923373	U01CA233074
+sra	SRP187083	Single cell transcriptomics of human and mouse lung cancers reveals conserved myeloid populations across individuals and species	PRJNA524857	28-Feb-2019	30979687	R01AI084880
+sra	SRP150094	Integrated transcriptomic and proteomic analysis of primary human umbilical vein endothelial cells	PRJNA475283	8-Jun-2018	30983154	U24CA210985
+sra	SRP168173	PolyA-sequencing in IMR-32 neuroblastoma cells with shRNA mediated depletion of CDK12, CDK13 or GFP.	PRJNA504553	8-Nov-2018	30988284	P01CA154303
+sra	SRP168172	PolyA-sequencing in Kelly and Kelly E9R neuroblastoma cells treated with THZ531 or DMSO	PRJNA504554	8-Nov-2018	30988284	P01CA154303
+sra	SRP120172	Human CXCR5+CD45RA-CD8+ T cells subset in follicular lymphoma	PRJNA414624	17-Oct-2017	31028278	R01AI109294
+sra	SRP106891	Tumor microenvironment-activated angiotensin blockers enhance cancer immunotherapy	PRJNA386326	11-May-2017	31040208	R01CA208205
+sra	SRP188564	CD8+ T cells regulate tumor ferroptosis during cancer immunotherapy	PRJNA527311	15-Mar-2019	31043744	R01CA205426
+sra	SRP194099	Genome wide CRISPR screen for Venetoclax resisatnce in MOLM13 cells using Brunello library	PRJNA540212	29-Apr-2019	31048320	U54CA224019
+sra	SRP194098	Genome wide CRISPR screen for Venetoclax resisatnce in MOLM13 cells using Y. Kosuke library	PRJNA540211	29-Apr-2019	31048320	U54CA224019
+sra	SRP186687	Cancer Cell Line Encyclopedia (CCLE)	PRJNA523380	20-Feb-2019	31068700	U54CA224068
+sra	SRP186687	Cancer Cell Line Encyclopedia (CCLE)	PRJNA523380	20-Feb-2019	31068700	P50CA098258
+sra	SRP119053	Aging Human Hematopoietic Stem Cells Manifest Profound Epigenetic Reprogramming of Enhancers That May Predispose to Leukemia	PRJNA412479	28-Sep-2017	31085557	R01CA196658
+sra	SRP136009	Integrated Analysis of Whole-Genome ChIP-Seq and RNA-Seq Data of Primary Head and Neck Tumor Samples Associates HPV Integration Sites with Open Chromatin Marks (ChIP-Seq)	PRJNA438961	19-Mar-2018	31097695	U01CA217885
+sra	SRP136016	A Novel Functional Splice Variant of AKT3 Defined by Analysis of Alternative Splice Expression in HPV-Positive Oropharyngeal Cancers (RNA-Seq)	PRJNA438981	19-Mar-2018	31097695	U01CA217885
+sra	SRP194361	Distruption of TOX and TOX2 transcription factors in CAR T cells limits T cell exhaustion [ATAC-Seq]	PRJNA540590	1-May-2019	31152140	U01DE028227
+sra	SRP194360	Distruption of TOX and TOX2 transcription factors in CAR T cells limits T cell exhaustion [RNA-Seq]	PRJNA540585	1-May-2019	31152140	U01DE028227
+sra	SRP193759	Profiling of protrusion-enriched RNAs from human breast cancer cell line MDA-MB-231	PRJNA534487	24-Apr-2019	31188523	R21CA191179
+sra	SRP191615	Cross-species single-cell analysis of pancreatic ductal adenocarcinoma reveals cancer-associated fibroblasts expressing MHC class II	PRJNA531464	8-Apr-2019	31197017	R33CA206949
+sra	SRP186683	Transcriptome analysis of various TOX+ and TOX- tumor-infiltrating CD8 T cells and in vitro TOX over-expressing T cells.	PRJNA523937	23-Feb-2019	31207604	R01AR070234
+sra	SRP184654	KSDM1b Role in Ewing Sarcoma	PRJNA521471	8-Feb-2019	31231465	U54CA231641
+sra	SRP189472	Genomic analyses of primary mouse prostate organoid culture with overexpression of FOXA1	PRJNA529188	26-Mar-2019	31243370	U54CA224079
+sra	SRP173277	Distinct structural classes of activating FOXA1 alterations in prostate cancer progression [RNA-Seq]	PRJNA509422	11-Dec-2018	31243372	P50CA186786
+sra	SRP173276	Distinct structural classes of activating FOXA1 alterations in prostate cancer progression [ChIP-Seq]	PRJNA509421	11-Dec-2018	31243372	P50CA186786
+sra	SRP136603	Chromatin interaction of ERG and AR in established prostate cancer	PRJNA445955	28-Mar-2018	31296553	U54CA224079
+sra	SRP173943	Insulin induced alterations in chromatin acetylation and transcriptome in triple negative breast cancer cells	PRJNA510812	19-Dec-2018	31315653	R01CA192914
+sra	SRP183532	Molecular profiling stratifies diverse phenotypes of treatment-refractory metastatic castration-resistant prostate cancer	PRJNA520923	4-Feb-2019	31361600	R37CA230617
+sra	SRP151006	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [ribosome profiling]	PRJNA476979	20-Jun-2018	31366581	R37CA230617
+sra	SRP151006	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [ribosome profiling]	PRJNA476979	20-Jun-2018	31366581	U54CA224079
+sra	SRP151005	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [RNA-seq]	PRJNA476980	20-Jun-2018	31366581	R37CA230617
+sra	SRP151005	The androgen receptor regulates a druggable translational regulon in advanced prostate cancer [RNA-seq]	PRJNA476980	20-Jun-2018	31366581	U54CA224079
+sra	SRP212736	Gene expression data from IMR90 control, IMR90 shRRM2 and shRRM2/shp16	PRJNA552100	1-Jul-2019	31433975	U54CA224070
+sra	SRP173457	MUC1-C represses the RASSF1A tumor suppressor and activated Kras signaling in human carcinoma cells	PRJNA510078	14-Dec-2018	31435022	U01CA233084
+sra	SRP173457	MUC1-C represses the RASSF1A tumor suppressor and activated Kras signaling in human carcinoma cells	PRJNA510078	14-Dec-2018	31435022	U24CA232979
+sra	SRP213899	Ketone body signaling mediates intestinal stem cell homeostasis and adaptation to diet	PRJNA553549	9-Jul-2019	31442404	U54CA224068
+sra	SRP167968	Genome-wide gene-expression profile of mouse intestinal stem cells/progenitors/Paneth cells	PRJNA504033	6-Nov-2018	31442404	U54CA224068
+sra	SRP168253	Single-cell profiling guided combinatorial immunotherapy for breast cancer resistance to Her2/neu and CDK4/6 targeted therapy	PRJNA504662	8-Nov-2018	31444334	U54CA209978
+sra	SRP171158	Mutationally-activated PI3'-kinase-a promotes de-differentiation of lung tumors initiated by the BRAFV600E oncoprotein kinase	PRJNA507606	29-Nov-2018	31452510	R01CA131261
+sra	SRP186643	A lineage-resolved molecular atlas of C. elegans embryogenesis at single cell resolution	PRJNA523834	22-Feb-2019	31488706	U2CCA233285
+sra	SRP134375	Deletion of Lats 1 and 2 in mouse pancreatic acinar cells	PRJNA437647	9-Mar-2018	31513574	U01CA224145
+sra	SRP218939	Next genereration sequencing reveals that CNAs associated with cyclin E overexpression tranlate into changes in transcriptional output.	PRJNA561187	20-Aug-2019	31513970	U01CA217885
+sra	SRP214243	MUC1-C ACTIVATES THE NURD COMPLEX IN DEDIFFERENTIATION OF TRIPLE-NEGATIVE BREASTCANCER CELLS	PRJNA554094	11-Jul-2019	31519689	U01CA233084
+sra	SRP214243	MUC1-C ACTIVATES THE NURD COMPLEX IN DEDIFFERENTIATION OF TRIPLE-NEGATIVE BREASTCANCER CELLS	PRJNA554094	11-Jul-2019	31519689	U24CA232979
+sra	SRP217327	Napabucasin-mediated transcriptomic changes in human pancreatic cancer cell lines	PRJNA558548	4-Aug-2019	31527169	R33CA206949
+sra	SRP215841	Identification of PIKfyve kinase as a target in multiple myeloma	PRJNA555832	22-Jul-2019	31582538	U54CA224018
+sra	SRP218895	Retention of CD19 intron 2 contributes to CART-19 resistance in leukemias with subclonal frameshift mutations in CD19	PRJNA561160	20-Aug-2019	31591467	P01CA214278
+sra	SRP218895	Retention of CD19 intron 2 contributes to CART-19 resistance in leukemias with subclonal frameshift mutations in CD19	PRJNA561160	20-Aug-2019	31591467	U01CA232563
+sra	SRP121512	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [MeRIP-seq]	PRJNA415689	24-Oct-2017	31601799	R37CA230617
+sra	SRP217139	Lactate mediated epigenetic reprogramming during cancer associated fibroblast formation	PRJNA557889	1-Aug-2019	31663852	U24CA224020
+sra	SRP188729	Papillomavirus-Colonized Murine Skin Confers Cancer Resistance	PRJNA527818	18-Mar-2019	31666702	U01CA233097
+sra	SRP186949	In vitro and in vivo epigenome-wide CRISPR screens in mouse KrasG12D/P53-/- (KP) lung adenocarcinoma model	PRJNA524379	26-Feb-2019	31744829	U01CA233084
+sra	SRP224585	FBXW7 is a defining driver of uterine carcinosarcoma by promoting epithelial-mesenchymal transition	PRJNA576165	7-Oct-2019	31772025	R01CA211339
+sra	SRP214326	Single cell ATAC sequencing profile of quiescent mesenchymal progenitors	PRJNA554142	11-Jul-2019	31809738	U54CA231652
+sra	SRP213792	RNA-seq profiling of adult skeletal muscle after long term conditional knockout of Hic1 [TA RNA-seq]	PRJNA553290	8-Jul-2019	31809738	U54CA231652
+sra	SRP132021	Single cell RNA sequencing time-course of mesenchymal progenitors during regeneration after notexin induced muscle injury	PRJNA432604	1-Feb-2018	31809738	U54CA231652
+sra	SRP222871	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [RNA-Seq II]	PRJNA573462	21-Sep-2019	31821784	R01CA176745
+sra	SRP222870	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [Cut&amp;Run]	PRJNA573463	21-Sep-2019	31821784	R01CA176745
+sra	SRP187096	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [ChIP-seq]	PRJNA524887	28-Feb-2019	31821784	R01CA176745
+sra	SRP220659	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy [scRNA-seq]	PRJNA564283	6-Sep-2019	31827283	R01CA221290
+sra	SRP220658	CRISPR screening reveals targets to reprogram long-lived effector CD8+ T cells for cancer therapy [ATAC-seq]	PRJNA564279	6-Sep-2019	31827283	R01CA221290
+sra	SRP198497	A large peptidome dataset improves HLA class I epitope prediction across most of the human population	PRJNA543098	15-May-2019	31844290	U24CA224331
+sra	SRP126055	RUVBL1/RUVBL2 ATPase Activity Drives PAQosome Maturation, DNA Replication and Radioresistance in Lung Cancer	PRJNA420950	4-Dec-2017	31883965	R01CA124633
+sra	SRP222296	Transcriptomic profiling of mouse lung tumor cells in response to CDK7 inhibitor treatment	PRJNA566130	18-Sep-2019	31883968	P01CA154303
+sra	SRP055512	Gene expression profiling of patient's DCIS-IDC tandem lesions by RNA sequencing analysis	PRJNA276455	25-Feb-2015	31907974	R01CA207445
+sra	SRP301811	Regulatory T Cell depletion causes compensatory immune suppression and accelerated pancreatic carcinogenesis	PRJNA590272	18-Nov-2019	31911451	U01CA224145
+sra	SRP189142	Regulatory T cell depletion causes compensatory immune suppression and accelerated pancreatic carcinogenesis.	PRJNA528597	22-Mar-2019	31911451	U01CA224145
+sra	SRP156614	STRIPAK directs PP2A activity to promote oncogenic transformation	PRJNA485011	7-Aug-2018	31913126	U01CA217885
+sra	SRP156614	STRIPAK directs PP2A activity to promote oncogenic transformation	PRJNA485011	7-Aug-2018	31913126	U01DE028227
+sra	SRP222942	Androgen Receptor Degraders Overcome Common Resistance Mechanisms Developed During Prostate Cancer Treatment	PRJNA573618	23-Sep-2019	31931431	P50CA186786
+sra	SRP218453	MYC and Twist1 Expression in Cancer Cells Activates Host Macrophages to Enable metastasis	PRJNA560393	15-Aug-2019	31933479	U01CA231776
+sra	SRP225053	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [scRNASeq]	PRJNA576817	10-Oct-2019	31935369	P01CA154303
+sra	SRP199298	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [ChIP + ATAC]	PRJNA544436	23-May-2019	31935369	P01CA154303
+sra	SRP226622	DENDRO: genetic heterogeneity profiling and subclone detection by single-cell RNA sequencing	PRJNA578900	22-Oct-2019	31937348	P01CA210944
+sra	SRP226622	DENDRO: genetic heterogeneity profiling and subclone detection by single-cell RNA sequencing	PRJNA578900	22-Oct-2019	31937348	U2CCA233285
+sra	SRP226833	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	PRJNA579338	24-Oct-2019	31953400	U01CA233084
+sra	SRP226833	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	PRJNA579338	24-Oct-2019	31953400	U24CA232979
+sra	SRP226833	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	PRJNA579338	24-Oct-2019	34163028	U01CA233084
+sra	SRP226833	MUC1-C Drives Lineage Plasticity in Progression to Neuroendocrine Prostate Cancer	PRJNA579338	24-Oct-2019	34163028	U24CA232979
+sra	SRP192022	MLL-Menin inhibition reverses pre-leukemic progenitor self-renewal induced by NPM1c mutations [RNA-Seq]	PRJNA532383	11-Apr-2019	32001657	R01CA176745
+sra	SRP199773	ATAC-seq in ARID1A WT or KO OVCA429 Cells after interferron treatment	PRJNA545316	29-May-2019	32027624	P50CA186786
+sra	SRP199772	Intersection of ARID1A, EZH2 RNA-seq in OVCA429 cells with IFN? treatment	PRJNA545317	29-May-2019	32027624	P50CA186786
+sra	SRP173553	The single cell transcriptional landscape of a mouse model of lung cancer metastasis	PRJNA510250	16-Dec-2018	32042191	U2CCA233284
+sra	SRP173552	The single cell transcriptional landscape of human lung adenocarcinoma (primary tumours and metastases)	PRJNA510251	16-Dec-2018	32042191	U2CCA233284
+sra	SRP221282	Blockade of lL17 signaling reverses alcohol-induced liver injury, and excessive alcohol drinking in mice.	PRJNA564833	10-Sep-2019	32051339	U01AA027681
+sra	SRP247892	Single residue in CD28-costimulated CAR-T cells limits long-term persistence and antitumor durability	PRJNA605702	10-Feb-2020	32069268	P01CA214278
+sra	SRP235221	The landscape of alternative splicing in aggressive prostate cancers	PRJNA594270	9-Dec-2019	32086391	U01CA233074
+sra	SRP235221	The landscape of alternative splicing in aggressive prostate cancers	PRJNA594270	9-Dec-2019	32086391	U24CA232979
+sra	SRP241924	Joint Profiling of Chromatin Accessibility and CAR-T Integration Site Analysis at Population and Single-cell Levels II	PRJNA601177	14-Jan-2020	32094195	P01CA214278
+sra	SRP241923	Joint Profiling of Chromatin Accessibility and CAR-T Integration Site Analysis at Population and Single-cell Levels I	PRJNA601178	14-Jan-2020	32094195	P01CA214278
+sra	SRP238470	Neurofibromin is an Estrogen Receptor alpha Transcriptional Co-repressor in Breast cancer	PRJNA597127	21-Dec-2019	32142667	U54CA233223
+sra	SRP225104	TEAD1 and TEAD3 play redundant roles in human epidermal proliferation	PRJNA576911	10-Oct-2019	32142794	U01CA217885
+sra	SRP233583	An immune-centric exploration of BRCA1 and BRCA2 germline mutation related breast and ovarian cancers	PRJNA592199	27-Nov-2019	32164626	R01CA226776
+sra	SRP197106	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [seq]	PRJNA541930	8-May-2019	32169821	R01CA176745
+sra	SRP220733	Differential modulation of the androgen receptor for prostate cancer therapy depends on the DNA response element	PRJNA564340	6-Sep-2019	32198885	P50CA186786
+sra	SRP223942	MYCN and MYC ChIP-Seq profiling in neuroblastoma cell lines	PRJNA575351	2-Oct-2019	32211329	U54CA232568
+sra	SRP187768	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [shRNA screen]	PRJNA525865	6-Mar-2019	32220301	U54CA224079
+sra	SRP230212	Discovery of a selective inhibitor of Doublecortin Like Kinase 1	PRJNA589887	15-Nov-2019	32251410	U01CA224146
+sra	SRP243832	Whole genome sequencing of bulk and single RPE-1 cells with induced chromosomal instability	PRJNA602546	21-Jan-2020	32299917	R33CA225344
+sra	SRP252454	High Throughput pMHC-I Tetramer Library Production Using Chaperone Mediated Peptide Exchange	PRJNA612056	11-Mar-2020	32312993	U54CA232568
+sra	SRP164390	Genome-wide survey of adjacent gene rearrangements in breast cancer identifies triple-negative specific BCL2L14-ETV6 fusions	PRJNA495013	8-Oct-2018	32321829	U54CA224076
+sra	SRP260906	scRNAseq of CD45+ cells within PDAC tumors treateted with CD40/ICB	PRJNA631402	9-May-2020	32324594	P01CA210944
+sra	SRP256482	Differential gene expression in mACVR1 NS v wt-ACVR1 NS.	PRJNA625523	15-Apr-2020	32332014	U01CA224160
+sra	SRP200058	Systematic comparative analysis of single cell RNA-sequencing methods	PRJNA545730	31-May-2019	32341560	U2CCA233195
+sra	SRP228608	Impact of splicing factors (ESRP1 and KHDRBS3) on prostate cancer biology	PRJNA587741	5-Nov-2019	32350277	U24CA232979
+sra	SRP188817	Therapeutic targeting of splicing in aggressive prostate cancer	PRJNA527978	19-Mar-2019	32350277	U24CA232979
+sra	SRP242206	Gene expression in DCIS.COM with BCL9 knockdown	PRJNA601728	16-Jan-2020	32352029	R01CA207445
+sra	SRP240551	BCL9/STAT3 Regulation of Transcriptional Enhancer Networks Promote DCIS Progression	PRJNA599998	8-Jan-2020	32352029	R01CA207445
+sra	SRP256199	Differentiated prostate luminal cells acquire enhanced regenerative potential after androgen ablation	PRJNA625051	11-Mar-2020	32355025	U54CA224079
+sra	SRP238472	Combined targeting of the BRD4-NUT-p300 axis in NUT midline carcinoma by dual selective bromodomain inhibitor, NEO2734	PRJNA597130	21-Dec-2019	32371576	R01CA124633
+sra	SRP226854	Somatic tissue engineering in mouse models reveals an actionable role for WNT pathway alterations in prostate cancer metastasis	PRJNA579352	24-Oct-2019	32376773	U54CA224079
+sra	SRP255477	Clinically-relevant cell type cross-talk identified from a lung tumor microenvironment interactome	PRJNA438518	15-Mar-2018	32381040	U24CA224309
+sra	SRP257861	“Direct to Drug” screening as a precision medicine tool in multiple myeloma	PRJNA627346	15-Apr-2020	32393731	U54CA224018
+sra	SRP260068	Transcriptional landscape of four exhausted CD8 T cell subsets	PRJNA630424	5-May-2020	32396847	P01CA210944
+sra	SRP260066	Epigenetic landscape of four exhausted CD8 T cell subsets	PRJNA630423	5-May-2020	32396847	P01CA210944
+sra	SRP200090	Alternative splicing of LSD1+8a is mediated by SRRM4 in Neuroendocrine Prostate Cancer	PRJNA545801	1-Jun-2019	32403054	P50CA186786
+sra	SRP185483	Peri-pancreatic LN cDC1 KPC	PRJNA521746	11-Feb-2019	32453421	P01CA210944
+sra	SRP185482	Inguinal LN cDC1 SubQ KPC	PRJNA521744	11-Feb-2019	32453421	P01CA210944
+sra	SRP167882	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (RNA-seq - simultaneous)	PRJNA503880	5-Nov-2018	32471953	U54CA224019
+sra	SRP167881	CEBPA Dysfunction Intiates CSF3R Mutant Acute Myeloid Leukemia Through Disruption of Myeloid Lineage Enhancers (RNA-seq - orders)	PRJNA503881	5-Nov-2018	32471953	U54CA224019
+sra	SRP201753	The major pre- and post-menopausal estrogens play opposing roles in obesity driven mammary inflammation and breast cancer development	PRJNA549449	18-Jun-2019	32492394	R01CA210440
+sra	SRP254656	Comparison of mRNA profiles of AGO2 sufficent and deficient pancreatic tissue in the LSL KRASG12D mouse model of pancreatic cancer	PRJNA616355	30-Mar-2020	32499547	U01CA224145
+sra	SRP230181	Single Cell Analysis Reveals NUPR1 Promotes Docetaxel Resistance in Prostate Cancer	PRJNA589746	15-Nov-2019	32513898	P50CA186786
+sra	SRP186092	Epidermal basal cell-specific in vivo ribosome profiling to describe the translation landscape of HrasG12V and Eif2b5	PRJNA522866	16-Feb-2019	32516567	R37CA230617
+sra	SRP189732	Inter-myeloid cell synaptic antigen dispersal drives diversified anti-tumor T cell priming	PRJNA529639	28-Mar-2019	32516589	R01CA197363
+sra	SRP260821	Quantitative Analysis of Wild Type and CISH-/- induced pluripotent stem cell derived NK cells (iPSC-NK) Transcriptomes	PRJNA631264	8-May-2020	32531207	U01CA217885
+sra	SRP243450	Transcriptional profiling of ribociclib-treated sensitive and ribociclib resistant CAMA-1 cells	PRJNA602306	20-Jan-2020	32565737	U54CA209978
+sra	SRP193372	Signaling state and abundance of circulating immune cell subpopulations determine cancer response to immunotherapy	PRJNA534106	22-Apr-2019	32571915	U54CA209978
+sra	SRP255945	Transcriptomic analysis of IRAK4 in murine pancreatic cancer cells (KP2)	PRJNA624277	10-Apr-2020	32573499	U54CA224083
+sra	SRP258057	Novel Inhibitors of the Histone-Methyltransferase DOT1L Show Potent Antileukemic Activity in Patient-derived Xenografts (RNA-seq dataset)	PRJNA627611	23-Apr-2020	32575123	R01CA176745
+sra	SRP265179	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [WES]	PRJNA603106	24-Jan-2020	32579974	U2CCA233195
+sra	SRP265179	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [WES]	PRJNA603106	24-Jan-2020	32579974	U2CCA233238
+sra	SRP244706	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [single-cell RNA-seq]	PRJNA603103	24-Jan-2020	32579974	U2CCA233195
+sra	SRP244706	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [single-cell RNA-seq]	PRJNA603103	24-Jan-2020	32579974	U2CCA233238
+sra	SRP253678	Functional characterization of the novel GWAS-identified GP2 coding variant	PRJNA614018	23-Mar-2020	32581250	U01CA164973
+sra	SRP251986	IL-18BP is a secreted immune checkpoint and barrier to effective IL-18 immunotherapy	PRJNA611084	8-Mar-2020	32581358	U01CA233096
+sra	SRP250163	Recapitulation of Prostate Tissue Cell Type-specific Transcriptomes by an in vivo Primary Prostate Tissue Xenograft Model	PRJNA607784	20-Feb-2020	32584883	U24CA232979
+sra	SRP249916	ZipSeq : Barcoding for Real-time Mapping of Single Cell Transcriptomes	PRJNA607323	18-Feb-2020	32632238	R01CA197363
+sra	SRP212657	RNA seq to compare gene expression profiles between Npm1 WT and Npm1 knockdown cells	PRJNA551883	30-Jun-2019	32646968	P01CA154303
+sra	SRP265314	Neuropilin-1(NRP1) is a T cell memory checkpoint limiting long-term anti-tumor immunity	PRJNA635953	29-May-2020	32661362	P01CA210944
+sra	SRP269098	The Tumor Microenvironment and Inflammation Influence toxicity in patients with Large B Cell Lymphoma Treated with Axicabtagene Ciloleucel [RNA-Seq]	PRJNA642648	28-Jun-2020	32669372	U01CA247576
+sra	SRP246236	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis [Cut&amp;Run ChIP-seq]	PRJNA604071	30-Jan-2020	32675324	U54CA243125
+sra	SRP261871	Single-cell atlas of human leptomeningeal metastasis	PRJNA633130	15-May-2020	32675368	U2CCA233284
+sra	SRP247504	Leptomeningeal metastatic cells outcompete macrophages for iron through Lipocalin-2	PRJNA605149	6-Feb-2020	32675368	U2CCA233284
+sra	SRP255006	RNA-seq analysis in NRG1 and enzalutamide treated 22Pc-EP cell line	PRJNA622705	2-Apr-2020	32679108	U54CA224079
+sra	SRP153070	M1hot tumour associated macrophages are positively associated with tissue-resident memory T cell responses and survival outcomes in human lung cancer (single cells).	PRJNA480671	11-Jul-2018	32699181	U01CA224766
+sra	SRP153069	M1hot tumour associated macrophages are positively associated with tissue-resident memory T cell responses and survival outcomes in human lung cancer (bulk).	PRJNA480670	11-Jul-2018	32699181	U01CA224766
+sra	SRP266023	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma [ChIP-seq]	PRJNA637386	4-Jun-2020	32699215	U54CA224081
+sra	SRP259644	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma	PRJNA630082	3-May-2020	32699215	U54CA224081
+sra	SRP259187	Multi-omics analysis reveals divergent epigenetic regulation of gene expression and drivers of esophageal squamous cell carcinoma (RNA-Seq)	PRJNA629358	29-Apr-2020	32699215	U54CA224081
+sra	SRP266202	Differential expression of endogenous retroelements (long terminal repeats) in ADA2 depleted primary endothelial cells (HUVECs)	PRJNA637655	5-Jun-2020	32743071	U01DE028227
+sra	SRP261562	Tanscriptional profile of primary endothelial cells (HUVEC) in ADA2 depleted setting and effect of Dipyridamole (DPM) treatment	PRJNA632723	14-May-2020	32743071	U01DE028227
+sra	SRP226107	A bifunctional nucleosome binding protein mediates specialized mSWI/SNF complex targeting and activity (RNA-seq dataset)	PRJNA578158	17-Oct-2019	32747783	U54CA231638
+sra	SRP268823	Identification of a CD117+? ?CD71+? ? early ?unipotent? neutrophil progenitor population in human bone marrow	PRJNA641887	25-Jun-2020	32814027	U01CA224766
+sra	SRP246912	Chromatin profiling of the relationship between EWS/FLI, LSD1, and K27ac in multiple Ewing sarcoma cell lines	PRJNA604586	3-Feb-2020	32842875	U54CA231641
+sra	SRP269753	Genome-scale CRISPR-Cas9 knockout screening for identification of genes which regulate CD38 expression in RPMI 8226 cells	PRJNA643779	2-Jul-2020	32844992	P01CA155258
+sra	SRP271143	Multivalent proteins rapidly and reversibly phase-separate upon osmotic cell volume change	PRJNA645164	9-Jul-2020	32857953	P50CA186786
+sra	SRP266970	Effect of bone marrow microenvironment on the sensitivity of breast cancer cells to antiestrogens	PRJNA638946	11-Jun-2020	32859606	U54CA224079
+sra	SRP266970	Effect of bone marrow microenvironment on the sensitivity of breast cancer cells to antiestrogens	PRJNA638946	11-Jun-2020	32859606	U54CA233223
+sra	SRP236894	Massively parallel and time-resolved RNA sequencing in single cells with scNT-Seq	PRJNA594978	11-Dec-2019	32868927	U2CCA233285
+sra	SRP257960	The Gustatory Sensory G-Protein GNAT3 Suppresses Pancreatic Cancer Progression in Mice	PRJNA627490	22-Apr-2020	32882403	U01CA224145
+sra	SRP275628	A Non-genetic Mechanism Involving the Integrin b4/Paxillin Axis Contributes to Chemoresistance in Lung Cancer	PRJNA650468	3-Aug-2020	32947124	U54CA209978
+sra	SRP273011	Overcoming primary and acquired resistance to anti-PD-L1 therapy by induction and activation of tumor-residing cDC1s	PRJNA647616	22-Jul-2020	33110069	U24CA232979
+sra	SRP275646	Role of PTEN in B-ALL	PRJNA650503	3-Aug-2020	33149299	U01CA232563
+sra	SRP273997	An Ifitm3-dependent amplification loop enables antibody responses and oncogenic signaling in B-cells	PRJNA649275	28-Jul-2020	33149299	U01CA232563
+sra	SRP285920	Functional Genomics Identifies Metabolic Vulnerabilities in Pancreatic Cancer [CRISPR Screen]	PRJNA666653	30-Sep-2020	33152323	U01CA224146
+sra	SRP285919	Functional Genomics Identifies Metabolic Vulnerabilities in Pancreatic Cancer [RNA-Seq]	PRJNA666652	28-Sep-2020	33152323	U01CA224146
+sra	SRP279024	ChIP-seq profiling of pancreatic tumor cells	PRJNA659482	26-Aug-2020	33158848	U54CA232568
+sra	SRP237758	Genome-wide maps of macroH2A and H2B distribution in murine embryonic fibroblasts in dependence of Lsh.	PRJNA595882	16-Dec-2019	33159050	R01CA163915
+sra	SRP262218	Quantitative Analysis of different NK cell types Transcriptomes	PRJNA633630	18-May-2020	33178188	U01CA217885
+sra	SRP261255	Quantitative Analysis of different NK cell types Transcriptomes	PRJNA631914	12-May-2020	33178188	U01CA217885
+sra	SRP233500	PD-1 and TIGIT co-expression identifies a circulating CD8 T cell population predictive of response to anti-PD-1 therapy in melanoma and Merkel-cell carcinoma patients [RNA-seq]	PRJNA592169	27-Nov-2019	33188038	UM1CA154967
+sra	SRP286166	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Pggt1b_ATACseq]	PRJNA667026	2-Oct-2020	33207246	R01CA221290
+sra	SRP286175	Protein prenylation drives discrete signaling programs for the differentiation and maintenance of effector Treg cells [Fntb_ATACseq]	PRJNA667029	2-Oct-2020	33207246	R01CA221290
+sra	SRP119365	Transcriptional Signaling Centers Regulate Erythroid Gene Expression and are Disrupted in Common Variations of Human Red Blood Cell Traits	PRJNA413084	3-Oct-2017	33230299	P01CA155258
+sra	SRP279627	Macrophage Gene Expression in PyMT Tumor Progression	PRJNA660767	1-Sep-2020	33257795	R01CA192914
+sra	SRP288281	Single Cell RNAseq on Renal adenocarcinoma	PRJNA670875	23-Oct-2020	33264598	R01CA197363
+sra	SRP269226	Protein synthesis inhibitors stimulate MondoA transcriptional activity by driving accumulation of glucose 6-phosphate	PRJNA642855	29-Jun-2020	33292639	U54CA224076
+sra	SRP255872	RNA-Seq of brain metastatic breast cancer cell lines after knockout of lipid metabolism genes using CRISPR/Cas9 gene editing	PRJNA624099	9-Apr-2020	33299191	R01CA208205
+sra	SRP287552	Targeting Transcriptional Regulation of SARS-CoV-2 Entry Factors ACE2 and TMPRSS2	PRJNA669811	19-Oct-2020	33310900	P50CA186786
+sra	SRP288305	Droplet based mRNA sequencing of fixed and permeabilized cells by CLInt-Seq allows for antigen specific TCR cloning	PRJNA670907	23-Oct-2020	33431692	U01CA233074
+sra	SRP285135	Targeted single-cell RNAseq of tonsil organoid cultures	PRJNA665262	23-Sep-2020	33432170	U54CA224081
+sra	SRP292343	Tumor-infiltrating mast cells are associated with resistance to anti-PD-1 therapy. [RNA-Seq]	PRJNA677942	12-Nov-2020	33436641	U54CA224070
+sra	SRP291283	Tumor-infiltrating mast cells are associated with resistance to anti-PD-1 therapy. [TCR]	PRJNA674781	5-Nov-2020	33436641	U54CA224070
+sra	SRP243766	Genomic alterations during the in situ to invasive ductal breast carcinoma transition shaped by the immune system	PRJNA602512	21-Jan-2020	33443130	U24CA224331
+sra	SRP300174	A CRISPR/Cas9-engineered ARID1A-deficient human gastric cancer organoid model reveals essential and non-essential modes of oncogenic transformation	PRJNA689437	4-Jan-2021	33451982	U54CA224081
+sra	SRP300174	A CRISPR/Cas9-engineered ARID1A-deficient human gastric cancer organoid model reveals essential and non-essential modes of oncogenic transformation	PRJNA689437	4-Jan-2021	33451982	R01CA163915
+sra	SRP291010	Inhibitory signaling sustains a distinct early memory CD8+ T cell precursor that is resistant to DNA damage	PRJNA674364	3-Nov-2020	33452106	P01CA210944
+sra	SRP285126	Cell-type, single-cell, and spatial signatures of brain-region specific splicing in postnatal development	PRJNA665252	23-Sep-2020	33469025	U24CA180996
+sra	SRP239279	Global gene expression analysis of breast cancer cell line responses to Topsentinol L Trisulfate or DMSO as the vehicle control	PRJNA598573	2-Jan-2020	33477536	U54CA209978
+sra	SRP292363	Single-cell lineages reveal the rates, routes, and drivers of metastasis in cancer xenografts	PRJNA677962	12-Nov-2020	33479121	U54CA224081
+sra	SRP252552	RNA editing enzyme APOBEC3A promotes pro-inflammatory (M1) macrophage polarization	PRJNA612213	12-Mar-2020	33483601	U24CA232979
+sra	SRP252552	RNA editing enzyme APOBEC3A promotes pro-inflammatory (M1) macrophage polarization	PRJNA612213	12-Mar-2020	33483601	R01CA188900
+sra	SRP300048	MUC1-C integrates activation of the IFN-? pathway with suppression of the tumor immune microenvironment in triple-negative breast cancer	PRJNA689212	2-Jan-2021	33495298	U01CA233084
+sra	SRP300048	MUC1-C integrates activation of the IFN-? pathway with suppression of the tumor immune microenvironment in triple-negative breast cancer	PRJNA689212	2-Jan-2021	33495298	U24CA232979
+sra	SRP306841	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [ChIPseq]	PRJNA702445	17-Feb-2021	33527899	R01CA204396
+sra	SRP279983	Single-cell B receptor VDJ sequencing from HGSOC isolated B cells	PRJNA661287	3-Sep-2020	33536615	R01CA211913
+sra	SRP279983	Single-cell B receptor VDJ sequencing from HGSOC isolated B cells	PRJNA661287	3-Sep-2020	33536615	U01CA232758
+sra	SRP258859	Genome-wide maps of histone modifications in mouse tumor-derived cell lines	PRJNA628863	28-Apr-2020	33536620	U54CA224065
+sra	SRP268591	SPT6 Promotes Epidermal Differentiation and Blockade of an Intestinal Phenotype through Control of Transcriptional Elongation	PRJNA641564	24-Jun-2020	33542242	U01CA217885
+sra	SRP256444	Gain-of-Function p53 Protein Transferred via Small Extracellular Vesicles Promotes Conversion of Fibroblasts to a Cancer-Associated Phenotype	PRJNA625457	15-Apr-2020	33567287	P50CA098258
+sra	SRP292585	Differential expression genes analysis of knocking down Prmt1 and Ripk1 in MC38/gp100 cell line	PRJNA678452	14-Nov-2020	33589527	R01CA187076
+sra	SRP265561	p300/CBP mediated activation of MHCI machinery and IFNg receptor loci controls chemoimmunotherapy	PRJNA636609	2-Jun-2020	33602823	U01AA027681
+sra	SRP265561	p300/CBP mediated activation of MHCI machinery and IFNg receptor loci controls chemoimmunotherapy	PRJNA636609	2-Jun-2020	33602823	U24CA232979
+sra	SRP302114	BAF subunit switching regulates chromatin accessibility to control cell cycle exit in the developing mammalian cortex [RNA-seq]	PRJNA692735	17-Jan-2021	33602870	R01CA163915
+sra	SRP253514	Transcriptional profiling of control versus PAF depleted human lung cancer cell line (H1792)	PRJNA613709	20-Mar-2020	33626321	U54CA224065
+sra	SRP304721	Lipid signalling enforces functional specialization of Treg cells in tumours [scRNA-seq EAE]	PRJNA699485	4-Feb-2021	33627871	R01CA221290
+sra	SRP273301	A bladder cancer patient-derived xenograft reflects aggressive growth dynamics in vivo and in organoids	PRJNA648129	23-Jul-2020	33633154	R37CA230617
+sra	SRP295963	ArchR: An integrative and scalable software package for single-cell chromatin accessibility analysis	PRJNA682619	4-Dec-2020	33633365	U2CCA233311
+sra	SRP289484	In vivo CRISPR screening reveals nutrient signaling processes underpinning CD8+ T cell fate decisions [Pofut1 ATAC-seq]	PRJNA672934	28-Oct-2020	33636132	R01CA221290
+sra	SRP253428	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	PRJNA613594	20-Mar-2020	33658518	U54CA224079
+sra	SRP253428	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	PRJNA613594	20-Mar-2020	34244513	R37CA230617
+sra	SRP253428	Combined TP53 and RB1 Loss Promotes Prostate Cancer Resistance to a Broad Spectrum of Cancer Therapeutics and Confers Vulnerability to Replication Stress	PRJNA613594	20-Mar-2020	34244513	U54CA224079
+sra	SRP254945	The Androgen Receptor Directly Regulates CD44 Expression in Androgen Sensitive Bladder Cancer [ChIP-seq]	PRJNA622581	1-Apr-2020	33687952	R01CA143971
+sra	SRP313387	Regnase-1 suppresses TCF-1+ precursor exhausted T cell formation to limit CAR T cell responses against ALL [WGBS]	PRJNA719647	4-Apr-2021	33690816	R01CA221290
+sra	SRP265464	T cell receptor repertoire analysis of tumor-infiltrating T cells in non-small cell lung cancer [tumor_T_cells]	PRJNA636300	1-Jun-2020	33691136	U54CA232568
+sra	SRP292937	PolyA-sequencing in Jurkat cells upon CDK12 depletion.	PRJNA679028	17-Nov-2020	33753926	P01CA154303
+sra	SRP309720	Longitudinal single-cell epitope and RNA-sequencing reveals the immunological impact of type 1 interferon autoantibodies in critical COVID-19	PRJNA707445	8-Mar-2021	33758859	P01AI118688
+sra	SRP284880	Pancreatic cancer is marked by complement-high blood monocytes and tumor-associated macrophages	PRJNA664962	22-Sep-2020	33782087	U01CA224145
+sra	SRP301988	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [ATAC-seq]	PRJNA692498	15-Jan-2021	33795428	U54CA232568
+sra	SRP238563	Splicing Variation Contributes to Functional Dysregulation of Genes in Acute Myeloid Leukemia	PRJNA597243	22-Dec-2019	33876749	U01CA232563
+sra	SRP292529	CRISPR genome editing of human dendritic cells (treatments of knockout dendritic cells)	PRJNA678348	13-Nov-2020	33904395	U54CA224081
+sra	SRP310875	Human stem cell-derived pancreatic acini-like and duct-like organoids demonstrate lineage-specific differences to oncogene activation	PRJNA714896	16-Mar-2021	33915081	U01CA224193
+sra	SRP308387	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	PRJNA705184	26-Feb-2021	33976133	R01CA208205
+sra	SRP308387	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	PRJNA705184	26-Feb-2021	33976133	U01CA224348
+sra	SRP308387	Targeting Treg cells with GITR activation alleviates resistance to immunotherapy in murine glioblastomas	PRJNA705184	26-Feb-2021	33976133	U2CCA233262
+sra	SRP261101	cIAP1/2 antagonism eliminates MHC class I negative tumors through T cell-dependent reprogramming of mononuclear phagocytes	PRJNA631697	11-May-2020	34011631	U01CA224146
+sra	SRP290695	Apolipoprotein E promotes immune suppression in pancreatic cancer through NF-kB-mediated production of CXCL1	PRJNA673706	1-Nov-2020	34049975	U01CA224145
+sra	SRP320538	Dynamic patterns of DNA methylation in the normal prostate epithelial differentiation program are targets of aberrant methylation in prostate cancer [BiSulfite-seq]	PRJNA731168	19-May-2021	34075163	U24CA232979
+sra	SRP270319	Tumor transcriptomes profiling of SS18-SSX, Smarcb1-/- and combination of SS18-SSX and Smarcb1-/- driven tumor	PRJNA644360	6-Jul-2020	34078620	U54CA231652
+sra	SRP277341	TNF blockade uncouples toxicity and anti-tumor efficacy induced with an agonist CD40 antibody	PRJNA656939	13-Aug-2020	34101617	U01CA224193
+sra	SRP286808	PELP1/SRC-3-dependent regulation of metabolic kinases drives therapy resistant ER+ breast cancer [3D]	PRJNA668175	8-Oct-2020	34103681	U54CA224076
+sra	SRP301757	High-fat diet activated fatty acid oxidation mediates intestinal stemness and tumorigenicity	PRJNA692179	14-Jan-2021	34107251	U01CA250554
+sra	SRP301757	High-fat diet activated fatty acid oxidation mediates intestinal stemness and tumorigenicity	PRJNA692179	14-Jan-2021	34107251	U54CA224068
+sra	SRP302344	Longitudinal single-cell dynamics in chronic lymphocytic leukemia mirror disease history	PRJNA693244	19-Jan-2021	34112698	U24CA224331
+sra	SRP318107	mSWI/SNF promotes polycomb repression both directly and through genome-wide redistribution [ChIP-seq]	PRJNA726623	29-Apr-2021	34117481	R01CA163915
+sra	SRP303823	The effect of STAG2 loss in Ewing sarcoma [ChIP-seq]	PRJNA697910	29-Jan-2021	34129824	R01CA204915
+sra	SRP267182	Visualizing programmed lineage trajectories at cancer initiation	PRJNA639282	13-Jun-2020	34131071	U24CA209923
+sra	SRP221563	Characterization of transcriptional analysis of LKB1 mutant lung nodules	PRJNA565371	13-Sep-2019	34142094	U01CA233084
+sra	SRP254894	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [RNA-seq]	PRJNA622461	1-Apr-2020	34145028	U54CA224079
+sra	SRP254894	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [RNA-seq]	PRJNA622461	1-Apr-2020	34145028	P50CA186786
+sra	SRP294495	Spike-in normalization for single-cell RNA-seq reveals dynamic global transcriptional activity mediating anti-cancer drug response	PRJNA681205	27-Nov-2020	34159316	R33CA225323
+sra	SRP318897	Immune checkpoint blockade reprograms systemic immune landscape and tumor microenvironment in obesity-associated breast cancer [tumor]	PRJNA728069	7-May-2021	34161764	R01CA229164
+sra	SRP285763	Genome-wide CRISPR rensensitization screens in FGF2 and FL-derived Early and Late Gilteritinib Resistant MOLM14 cultures using Y. Kosuke library	PRJNA666344	29-Sep-2020	34171263	U54CA224019
+sra	SRP293634	Transcriptome Analysis of treated cells in Philadelphia Chromosome-Like Acute Lymphoblastic Leukemia	PRJNA679952	21-Nov-2020	34210682	U01CA232486
+sra	SRP319403	10X Genomics single-cell RNAseq combined with CRISPR tiling of Dot1l in mouse MLL-AF9 leukemia	PRJNA729273	12-May-2021	34210975	R01CA176745
+sra	SRP322468	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	PRJNA734933	3-Jun-2021	34215680	R01CA208205
+sra	SRP322468	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	PRJNA734933	3-Jun-2021	34215680	U01CA224348
+sra	SRP322468	Resident Kupffer cells and neutrophils drive liver toxicity in cancer immunotherapy	PRJNA734933	3-Jun-2021	34215680	R01AI084880
+sra	SRP320718	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (Exome-Seq)	PRJNA731519	20-May-2021	34244513	R37CA230617
+sra	SRP320718	Multiplexed functional genomic analysis of somatic 5' untranslated region mutations across the spectrum of human prostate cancer (Exome-Seq)	PRJNA731519	20-May-2021	34244513	U54CA224079
+sra	SRP272605	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (ChIP-seq)	PRJNA647369	20-Jul-2020	34282330	U01DE028227
+sra	SRP327407	RNA-seq on NUT Carcinoma (NC) cell lines treated with DMSO, Panobinostat or IRBM6	PRJNA744556	7-Jul-2021	34285087	R01CA124633
+sra	SRP285426	RNA splicing factors SRRM3 and SRRM4 distinguish molecular phenotypes of castration-resistant neuroendocrine prostate cancer [RNA-seq]	PRJNA665740	25-Sep-2020	34312180	P50CA186786
+sra	SRP255626	SMAD4 represses FOSL1 expression and pancreatic cancer metastatic colonization	PRJNA623590	7-Apr-2020	34320363	U01CA224146
+sra	SRP261076	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	PRJNA631627	11-May-2020	34329586	R01CA204915
+sra	SRP261076	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	PRJNA631627	11-May-2020	34329586	U54CA231637
+sra	SRP261076	RNA-seq profiling of Ewing sarcoma cells after TRIM8 knockout and EWS/FLI over-expression	PRJNA631627	11-May-2020	34329586	U54CA231641
+sra	SRP256219	Generation of a functional, patient specific human thymus from induced pluripotent stem cell in vivo	PRJNA624651	10-Apr-2020	34331993	R01CA213102
+sra	SRP325983	CXCR6 Positions Cytotoxic T Cells to Receive Critical Survival Signals in the Tumor Microenvironment	PRJNA742240	29-Jun-2021	34343496	R01AI084880
+sra	SRP282058	Labile Iron Release Primes Pancreatic Cancer for Ferroptosis	PRJNA662926	11-Sep-2020	34381026	U01CA224145
+sra	SRP324489	Downregulation of exhausted cytotoxic T cells in gene expression networks of multisystem inflammatory syndrome in children	PRJNA738854	17-Jun-2021	34381049	U01DK124165
+sra	SRP324489	Downregulation of exhausted cytotoxic T cells in gene expression networks of multisystem inflammatory syndrome in children	PRJNA738854	17-Jun-2021	34381049	U24CA224319
+sra	SRP331008	RNA-Seq of MSK-PCa series of Patient Derived Organoids and Xenografts	PRJNA751853	3-Aug-2021	34417459	R37CA230617
+sra	SRP331008	RNA-Seq of MSK-PCa series of Patient Derived Organoids and Xenografts	PRJNA751853	3-Aug-2021	34417459	U54CA224079
+sra	SRP303993	Co-evolving JAK2V617F+ relapsed AML and donor T cells with PD-1 blockade after stem cell transplantation: an index case [TCR-seq]	PRJNA698349	31-Jan-2021	34432868	U24CA224331
+sra	SRP321707	YBX1 mediates translation of oncogenic transcripts to control cell competition in AML [RNA-seq polysomes]	PRJNA733248	27-May-2021	34465866	R01CA176745
+sra	SRP330081	Dietary suppression of MHC-II expression in intestinal epithelial cells enhances intestinal tumorigenesis	PRJNA750096	27-Jul-2021	34529935	U01CA250554
+sra	SRP242232	Transcriptional profiling of distinct fibroblast populations in the pancreatic tumor microenvironment	PRJNA601743	16-Jan-2020	34548310	U01CA224193
+sra	SRP314343	Bortezomib induces anti-multiple myeloma immune response mediated by cGAS/STING pathway activation	PRJNA721176	11-Apr-2021	34568832	P01CA155258
+sra	SRP295518	Chromatin accessibility associates with protein-RNA correlation in human cancer	PRJNA682135	2-Dec-2020	34593797	U2CCA233311
+sra	SRP309174	Pathway Signatures Derived from On-treatment Tumor Specimens Predict Response to Anti-PD1 Blockade in Metastatic Melanoma	PRJNA706446	3-Mar-2021	34654806	U54CA224070
+sra	SRP278653	Altered BAF53A (ACTL6A) Stoichiometry Drives Human Squamous Cell Carcinoma [ATAC-seq]	PRJNA659022	24-Aug-2020	34687603	R01CA163915
+sra	SRP256724	Potent androgen receptor inhibition unleashes oncogenic action of the KLF5 stem cell transcription factor in castration-resistant prostate cancer [ChIP-seq]	PRJNA625790	16-Apr-2020	34737261	R37CA230617
+sra	SRP323037	Single-cell Multi-omics Defines Tolerogenic Extrathymic Aire-Expressing Populations with Unique Homology to Thymic Epithelium	PRJNA735721	7-Jun-2021	34767455	P01AI118688
+sra	SRP344663	H3K27 tri-methylation signature in CML CD34+ cells	PRJNA777969	4-Nov-2021	34780648	R01CA229875
+sra	SRP301119	Exceptional response of high-risk neuroblastoma to RBM39 degrader Indisulam (ATAC-Seq)	PRJNA691027	10-Jan-2021	34788094	U01CA232488
+sra	SRP294135	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma	PRJNA680750	25-Nov-2020	34795254	U2CCA233195
+sra	SRP294135	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma	PRJNA680750	25-Nov-2020	34795254	U2CCA233238
+sra	SRP294135	Immune cell topography predicts response to PD-1 blockade in cutaneous T cell lymphoma	PRJNA680750	25-Nov-2020	34795254	UM1CA154967
+sra	SRP268138	Predicting master transcription factors from pan-cancer expression data	PRJNA640799	20-Jun-2020	34818047	P01CA155258
+sra	SRP335232	Phenotypic consequences of SLC25A40-ABCB1 fusions beyond drug resistance in High Grade Serous Ovarian Cancer	PRJNA759615	1-Sep-2021	34830797	U54CA209978
+sra	SRP340749	Phase Separation by the NUP98-HOXA9 Fusion Oncoprotein Drives an Oncogenic Phenotype in Hematopoietic Cells	PRJNA770091	10-Oct-2021	34903620	U54CA243124
+sra	SRP337782	RNA-sequencing of tumor infiltrating cells across 12 different solid tumors type	PRJNA764510	19-Sep-2021	34963056	R01CA197363
+sra	SRP337782	RNA-sequencing of tumor infiltrating cells across 12 different solid tumors type	PRJNA764510	19-Sep-2021	34963056	U54CA224081
+sra	SRP329329	MUC1-C DICTATES JUN AND BAF-MEDIATED CHROMATIN REMODELING AT PROMOTER AND ENHANCER SIGNATURES IN CANCER STEM CELLS	PRJNA748762	21-Jul-2021	35022313	U01CA233084
+sra	SRP329329	MUC1-C DICTATES JUN AND BAF-MEDIATED CHROMATIN REMODELING AT PROMOTER AND ENHANCER SIGNATURES IN CANCER STEM CELLS	PRJNA748762	21-Jul-2021	35022313	U24CA232979
+sra	SRP092004	Suppression of adaptive responses to targeted cancer therapy by transcriptional repression [RNA-seq]	PRJNA350335	24-Oct-2016	29054992	P01CA154303
+sra	SRP125437	How HLA influences response to immunotherapy (Part 2)	PRJNA419422	21-Nov-2017	29217585	R01CA205426
+sra	SRP125435	How HLA influences response to immunotherapy (Part 1)	PRJNA419415	21-Nov-2017	29217585	R01CA205426
+sra	SRP073112	Enhancer invasion shapes MYCN dependent transcriptional amplification in neuroblastoma [RNA-seq]	PRJNA318042	11-Apr-2016	29379199	P01CA155258
+sra	SRP058311	BRCA1, R-loops and Recombination defects in Ewing''s sarcoma (DRIP-seq)	PRJNA283900	13-May-2015	29513652	R01CA204915
+sra	SRP058310	BRCA1, R-loops and Recombination defects in Ewing''s sarcoma (RNA-seq)	PRJNA283885	13-May-2015	29513652	R01CA204915
+sra	SRP126845	Systematic assessment of next-generation sequencing for quantitative small RNA profiling: A-to-I editing pools	PRJNA422572	15-Dec-2017	30010675	P50CA186786
+sra	SRP173275	Nr4a transcription factors limit CAR-T cell function in solid tumors [ATAC-Seq]	PRJNA509426	11-Dec-2018	30814732	U01DE028227
+sra	SRP100709	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [RNA-Seq]	PRJNA376775	24-Feb-2017	31601799	R37CA230617
+sra	SRP120964	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis[Ribosome Profiling]	PRJNA415390	23-Oct-2017	31601799	R37CA230617
+sra	SRP120963	N6-methyladenosine mRNA marking promotes selective translation of regulons required for human erythropoiesis [crispr]	PRJNA415385	23-Oct-2017	31601799	R37CA230617
+sra	SRP187093	A novel Menin-MLL inhibitor induces specific chromatin changes and eradicates disease in models of MLL-rearranged leukemia [RNA-seq]	PRJNA524886	28-Feb-2019	31821784	R01CA176745
+sra	SRP199134	Treatment-induced tumor dormancy through YAP-mediated transcriptional reprogramming of the apoptotic pathway [YAP1 KO vs CTRL]	PRJNA544119	21-May-2019	31935369	P01CA154303
+sra	SRP192020	MLL-Menin inhibition reverses pre-leukemic progenitor self-renewal induced by NPM1c mutations [ChIP-Seq]	PRJNA532384	11-Apr-2019	32001657	R01CA176745
+sra	SRP199170	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [MIXCR]	PRJNA544179	22-May-2019	32169821	R01CA176745
+sra	SRP199112	H3K36 methyltransferase SETD2 regulates lymphoid and neural development [RNA-seq]	PRJNA544097	21-May-2019	32169821	R01CA176745
+sra	SRP186959	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [ATAC-seq]	PRJNA524393	26-Feb-2019	32220301	U54CA224079
+sra	SRP186568	Loss of CHD1 promotes chromatin dysregulation leading to heterogeneous mechanisms of resistance to hormone therapy in prostate cancer [RNA-seq]	PRJNA523728	22-Feb-2019	32220301	U54CA224079
+sra	SRP258055	Novel Inhibitors of the Histone-Methyltransferase DOT1L Show Potent Antileukemic Activity in Patient-derived Xenografts (ChIP-seq dataset)	PRJNA627612	23-Apr-2020	32575123	R01CA176745
+sra	SRP262989	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [ST]	PRJNA603104	24-Jan-2020	32579974	U2CCA233195
+sra	SRP262989	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [ST]	PRJNA603104	24-Jan-2020	32579974	U2CCA233238
+sra	SRP244707	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [CRISPR screen]	PRJNA603105	24-Jan-2020	32579974	U2CCA233195
+sra	SRP244707	Single Cell and Spatial Analysis of Human Squamous Cell Carcinoma [CRISPR screen]	PRJNA603105	24-Jan-2020	32579974	U2CCA233238
+sra	SRP220703	Comparison of tumor-associated YAP1 fusions identifies a recurrent set of functions critical for oncogenesis[RNASeq]	PRJNA564315	6-Sep-2019	32675324	U54CA243125
+sra	SRP226106	A bifunctional nucleosome binding protein mediates specialized mSWI/SNF complex targeting and activity (ChIP-seq dataset)	PRJNA578157	17-Oct-2019	32747783	U54CA231638
+sra	SRP246691	Chromatin profiling of the relationship between EWS/FLI, LSD1, and H3K27 acetylation	PRJNA604452	2-Feb-2020	32842875	U54CA231641
+sra	SRP201379	Chromatin profiling of the relationship between EWS/FLI, LSD1, and the enhancer landscape - H3K4 methylation	PRJNA548790	13-Jun-2019	32842875	U54CA231641
+sra	SRP252471	Transcriptional profiling of mouse pancreatic tumor cells II	PRJNA612068	11-Mar-2020	33158848	U54CA232568
+sra	SRP252467	Transcriptional profiling of mouse pancreatic tumor cells III	PRJNA612067	11-Mar-2020	33158848	U54CA232568
+sra	SRP252462	Transcriptional profiling of mouse pancreatic tumor cells I	PRJNA612069	11-Mar-2020	33158848	U54CA232568
+sra	SRP233499	PD-1 and TIGIT co-expression identifies a circulating CD8 T cell population predictive of response to anti-PD-1 therapy in melanoma and Merkel-cell carcinoma patients [TCR-seq]	PRJNA592172	27-Nov-2019	33188038	UM1CA154967
+sra	SRP065489	BMP signaling cooperates with GATA factors to govern stage-specific gene expression during erythroid differentiation [ChIP-Seq]	PRJNA300539	29-Oct-2015	33230299	P01CA155258
+sra	SRP255700	RNA-Seq of multiplexed metastasis xenogfrates of barcoded cell line pools	PRJNA623730	8-Apr-2020	33299191	R01CA208205
+sra	SRP298440	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [RNAseq_4cellLines]	PRJNA686294	18-Dec-2020	33527899	R01CA204396
+sra	SRP298437	Convergent organization of aberrant MYB complexes controls oncogenic gene expression in acute myeloid leukemia [RNAseq_MV411]	PRJNA686277	18-Dec-2020	33527899	R01CA204396
+sra	SRP265453	T cell receptor repertoire analysis of tumor-infiltrating T cells in non-small cell lung cancer [tet_sorted_PBLT_cells]	PRJNA636290	1-Jun-2020	33691136	U54CA232568
+sra	SRP301987	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [RNA-seq]	PRJNA692500	15-Jan-2021	33795428	U54CA232568
+sra	SRP301986	Transient “rest” induces functional reinvigoration and epigenetic remodeling in exhausted CAR-T cells Mediate Enhanced Antitumor Activity [ATAC-seq, ChIP-seq]	PRJNA692499	15-Jan-2021	33795428	U54CA232568
+sra	SRP292473	CRISPR genome editing of human dendritic cells (treatments of unedited dendritic cells)	PRJNA678225	13-Nov-2020	33904395	U54CA224081
+sra	SRP270318	RNAseq analysis of synovial sarcoma (SS), Smarcb1-/- and combined genotype of SS18-SSX and Smarcb1-/- mouse tumors	PRJNA644359	6-Jul-2020	34078620	U54CA231652
+sra	SRP298669	Longitudinal single-cell dynamics of mitochondrial mutations in chronic lymphocytic leukemia mirror disease history	PRJNA686864	21-Dec-2020	34112698	U24CA224331
+sra	SRP316738	mSWI/SNF promotes polycomb repression both directly and through genome-wide redistribution [RNA-seq]	PRJNA725842	28-Apr-2021	34117481	R01CA163915
+sra	SRP254893	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ChIP-seq]	PRJNA622462	1-Apr-2020	34145028	U54CA224079
+sra	SRP254893	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ChIP-seq]	PRJNA622462	1-Apr-2020	34145028	P50CA186786
+sra	SRP254892	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ATAC-seq]	PRJNA622463	1-Apr-2020	34145028	U54CA224079
+sra	SRP254892	Chromatin Occupancy of AR, BRD4, and H3K27Ac in MR42D Cells in response to Enzalutamide [ATAC-seq]	PRJNA622463	1-Apr-2020	34145028	P50CA186786
+sra	SRP272607	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (RNA-seq)	PRJNA647370	20-Jul-2020	34282330	U01DE028227
+sra	SRP272604	BATF and IRF4 cooperate to counter exhaustion in tumour-infiltrating CAR T cells (ATAC-seq)	PRJNA647372	20-Jul-2020	34282330	U01DE028227
+sra	SRP261351	Predicting Master Transcription Factors from Pan-Cancer Expression Data	PRJNA632047	12-May-2020	34818047	P01CA155258
+sra	SRP324312	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-ChIP-Seq	PRJNA738285	15-Jun-2021	34166225	R01CA241452
+sra	SRP324312	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-ChIP-Seq	PRJNA738285	15-Jun-2021	34166225	U10CA180899
+sra	SRP349414	Transcriptomic data of cord blood CD34+ cells as controls of transcriptome cohort of pediatric acute myeloid leukemia	PRJNA786561	6-Dec-2021	35176137	U10CA180899
+sra	SRP357187	Multi-omics analysis of RNA binding, splicing and turnover alterations induced by mutant U2AF1 in myeloid malignancies.	PRJNA801503	28-Jan-2022	35303483	R01CA222518
+sra	SRP324311	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-RNA-Seq	PRJNA738284	15-Jun-2021	34166225	R01CA241452
+sra	SRP324311	Germline RUNX1 Variation and Predisposition to Childhood Acute Lymphoblastic-RNA-Seq	PRJNA738284	15-Jun-2021	34166225	U10CA180899

--- a/tsv_digest_formatter.py
+++ b/tsv_digest_formatter.py
@@ -1,0 +1,115 @@
+import os.path
+from datetime import datetime
+
+import re
+import pandas as pd
+import numpy as np
+
+
+DATA_DIR = os.path.abspath("data")
+DIGEST_DIR = os.path.abspath("digest_data")
+EXTENSION = "tsv"
+
+# get publication file filenames
+publication_files = [f for f in os.listdir(DATA_DIR) if os.path.isfile(DATA_DIR+"/"+f) and f.split(".")[1] == EXTENSION and f.startswith("publication")]
+# get clinical trial filenames
+clinical_trial_files = [f for f in os.listdir(DATA_DIR) if os.path.isfile(DATA_DIR+"/"+f) and f.split(".")[1] == EXTENSION and f.startswith("clinical_trial")]
+# get sra filenames
+sra_files = [f for f in os.listdir(DATA_DIR) if os.path.isfile(DATA_DIR+"/"+f) and f.split(".")[1] == EXTENSION and f.startswith("sra")]
+# get geo filesnames
+geo_files = [f for f in os.listdir(DATA_DIR) if os.path.isfile(DATA_DIR+"/"+f) and f.split(".")[1] == EXTENSION and f.startswith("geo")]
+# get dbgap filenames
+dbgap_files = [f for f in os.listdir(DATA_DIR) if os.path.isfile(DATA_DIR+"/"+f) and f.split(".")[1] == EXTENSION and f.startswith("dbgap")]
+
+# load and consolidate data in all publication files
+df_publication = None
+for file in publication_files:
+    if df_publication is None:
+        df_publication = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+    else:
+        df_temp = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+        df_publication = pd.concat([df_publication, df_temp]).drop_duplicates().reset_index(drop=True)
+
+# load and consolidate data in all clinical trial files
+df_clinical_trials = None
+for file in clinical_trial_files:
+    if df_clinical_trials is None:
+        df_clinical_trials = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+    else:
+        df_temp = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+        df_clinical_trials = pd.concat([df_clinical_trials, df_temp]).drop_duplicates().reset_index(drop=True)
+
+# load and consolidate data in all sra files
+df_sra = None
+for file in sra_files:
+    if df_sra is None:
+        df_sra = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+    else:
+        df_temp = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+        df_sra = pd.concat([df_sra, df_temp]).drop_duplicates().reset_index(drop=True)
+
+# load and consolidate data in all geo files
+df_geo = None
+for file in geo_files:
+    if df_geo is None:
+        df_geo = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+    else:
+        df_temp = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+        df_geo = pd.concat([df_geo, df_temp]).drop_duplicates().reset_index(drop=True)
+
+# load and consolidate datta in all dbgap files
+df_dbgap = None
+for file in dbgap_files:
+    if df_dbgap is None:
+        df_dbgap = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+    else:
+        df_temp = pd.read_csv(DATA_DIR+"/"+file, sep="\t", dtype=object)
+        df_dbgap = pd.concat([df_dbgap, df_temp]).drop_duplicates().reset_index(drop=True)
+
+
+###################################
+# now we want to perform joins for each of clinical trials, sras, geos and dbgaps
+#   with the publication data to get associated 'queried_project_ids'
+###################################
+
+# clinical trials rename column 'publication.publication_id' to 'publication_id'
+df_clinical_trials = df_clinical_trials.rename(columns={"publication.publication_id": "publication_id"})
+# clinical trials, we don't want a duplicate 'project.queried_project_id' column
+#   just for clinical trials
+df_clinical_trials = df_clinical_trials.drop(columns=['project.queried_project_id'], axis=1)
+# clinical trials ignore rows with no 'publication_id', after droping 'project.queried_project_id' column
+#   just for clinical trials
+df_clinical_trials = df_clinical_trials[~pd.isna(df_clinical_trials["publication_id"])]
+# clinical trials join with publications in new column 'queried_project_id'
+df_clinical_trials["queried_project_id"] = df_clinical_trials.apply(lambda x: df_publication[df_publication["publication_id"] == x["publication_id"]]["project.queried_project_id"].tolist(), axis=1)
+df_clinical_trials = df_clinical_trials.explode("queried_project_id").reset_index(drop=True)
+# print the new clinical trials file
+df_clinical_trials.to_csv(f"{DIGEST_DIR}/digest_clinical_trial.tsv", sep="\t", index=False)
+
+# sra rename column 'publication.publication_id' to 'publication_id'
+df_sra = df_sra.rename(columns={"publication.publication_id": "publication_id"})
+# sra join with publications in new column 'queried_project_id'
+df_sra["queried_project_id"] = df_sra.apply(lambda x: df_publication[df_publication["publication_id"] == x["publication_id"]]["project.queried_project_id"].tolist(), axis=1)
+df_sra = df_sra.explode("queried_project_id").reset_index(drop=True)
+# print the new sra file
+df_sra.to_csv(f"{DIGEST_DIR}/digest_sra.tsv", sep="\t", index=False)
+
+# geo rename column 'publication.publication_id' to 'publication_id'
+df_geo = df_geo.rename(columns={"publication.publication_id": "publication_id"})
+# geo join with publications in new column 'queried_project_id'
+df_geo["queried_project_id"] = df_geo.apply(lambda x: df_publication[df_publication["publication_id"] == x["publication_id"]]["project.queried_project_id"].tolist(), axis=1)
+df_geo = df_geo.explode("queried_project_id").reset_index(drop=True)
+# print the new geo file
+df_geo.to_csv(f"{DIGEST_DIR}/digest_geo.tsv", sep="\t", index=False)
+
+# dbgap rename column 'publication.publication_id' to 'publication_id'
+df_dbgap = df_dbgap.rename(columns={"publication.publication_id": "publication_id"})
+# dbgap, we don't want a duplicate 'project.queried_project_id' column
+df_dbgap = df_dbgap.drop(columns=['project.queried_project_id'], axis=1)
+# dbgap ignore rows with no 'publication_id', after droping 'project.queried_project_id' column
+df_dbgap = df_dbgap[~pd.isna(df_dbgap["publication_id"])]
+# dbgap join with publications in new column 'queried_project_id'
+df_dbgap["queried_project_id"] = df_dbgap.apply(lambda x: df_publication[df_publication["publication_id"] == x["publication_id"]]["project.queried_project_id"].tolist(), axis=1)
+df_dbgap = df_dbgap.explode("queried_project_id").reset_index(drop=True)
+# print the new dbgap file
+df_dbgap.to_csv(f"{DIGEST_DIR}/digest_dbgap.tsv", sep="\t", index=False)


### PR DESCRIPTION
This was for Ricardo. He wanted tsv files with both core project ids (via publications) in the tsv files that normally just have the publication ids and just one file for each of the clinical trial, sra, geo and dbgap files.

This is to help with data validation.